### PR TITLE
fix!: state base coloring

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -282,7 +282,12 @@ export class Chart extends LitElement {
               typeof entityConf.color_below === 'undefined' ? 'var(--primary-color)' : entityConf.color_below;
             const colorAbove =
               typeof entityConf.color_above === 'undefined' ? 'var(--paper-item-icon-color)' : entityConf.color_above;
-            finalColor = state > colorLimit ? colorAbove : colorBelow;
+            if ( state > colorLimit ) {
+              finalColor = colorAbove;
+            }
+            if ( state < colorLimit ) {
+              finalColor = colorBelow;
+            }
           }
 
           return {

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -284,8 +284,7 @@ export class Chart extends LitElement {
               typeof entityConf.color_above === 'undefined' ? 'var(--paper-item-icon-color)' : entityConf.color_above;
             if ( state > colorLimit ) {
               finalColor = colorAbove;
-            }
-            if ( state < colorLimit ) {
+            } else if ( state < colorLimit ) {
               finalColor = colorBelow;
             }
           }


### PR DESCRIPTION
Fix state base coloring by allowing three-state display: state value below limit, state value equals limit and state value above limit.