### PR TITLE
fix: connection_entity_id and add_entities/subtract_entities

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -241,7 +241,7 @@ export class Chart extends LitElement {
           const { state } = normalizeStateValue(
             this.config.unit_prefix,
             Number(subEntity.state),
-            this._getUnitOfMeasurement(entityConf.unit_of_measurement || subEntity.attributes.unit_of_measurement)
+            this._getUnitOfMeasurement(subEntity.attributes.unit_of_measurement || unit_of_measurement)
           );
           normalized.state += state;
         });
@@ -252,7 +252,7 @@ export class Chart extends LitElement {
           const { state } = normalizeStateValue(
             this.config.unit_prefix,
             Number(subEntity.state),
-            this._getUnitOfMeasurement(entityConf.unit_of_measurement || subEntity.attributes.unit_of_measurement)
+            this._getUnitOfMeasurement(subEntity.attributes.unit_of_measurement || unit_of_measurement)
           );
           // stay positive
           normalized.state -= Math.min(state, normalized.state);

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -241,7 +241,7 @@ export class Chart extends LitElement {
           const { state } = normalizeStateValue(
             this.config.unit_prefix,
             Number(subEntity.state),
-            subEntity.attributes.unit_of_measurement || unit_of_measurement,
+            this._getUnitOfMeasurement(entityConf.unit_of_measurement || subEntity.attributes.unit_of_measurement)
           );
           normalized.state += state;
         });
@@ -252,7 +252,7 @@ export class Chart extends LitElement {
           const { state } = normalizeStateValue(
             this.config.unit_prefix,
             Number(subEntity.state),
-            subEntity.attributes.unit_of_measurement || unit_of_measurement,
+            this._getUnitOfMeasurement(entityConf.unit_of_measurement || subEntity.attributes.unit_of_measurement)
           );
           // stay positive
           normalized.state -= Math.min(state, normalized.state);

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -154,6 +154,11 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         if (ent.type === 'entity') {
           this.entityIds.push(ent.entity_id);
         }
+        ent.children.forEach(childConf => {
+          if (typeof childConf === 'object' && childConf.connection_entity_id) {
+            this.entityIds.push(childConf.connection_entity_id);
+          }
+        });
         if (ent.add_entities) {
           ent.add_entities.forEach(e => this.entityIds.push(e));
         }


### PR DESCRIPTION
- Fix `connection_entity_id`
  - If a `connection_entity_id` was specified, it was not added to the list of entities for which to retrieve the state. It seems that `connection_entity_id` only happened to work if that `entity_id` was also used elsewhere.
- Fix `add_entities`/`subtract_entities` normalization with unit conversion
  - When converting energy units, all the conversions take place in `energy.ts`, and the results can be directly added together. However, when `_getMemoizedState` was adding the values of `add_entities`, it didn't realize that the entities to add were already the correct values, and it erroneously normalized them. Now, the same "this has already been converted" logic used for the main entity state is also used for the `add_entity` state.