### PR TITLE
feat: `net_flows` option to show gross energy flows in autoconfig

### DIFF
--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -104,9 +104,9 @@ describe('SankeyChart autoconfig', () => {
     });
   });
 
-  it('removes subtract_entities with show_net_flows: false', async () => {
+  it('removes subtract_entities with net_flows: false', async () => {
     hass.states['sensor.grid_out'] = { entity_id: 'sensor.grid_out', state: '3' } as any;
-    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { show_net_flows: false } }, true);
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { net_flows: false } }, true);
     (getEnergyPreferences as jest.Mock).mockResolvedValue({
       energy_sources: [
         { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_energy_to: 'sensor.grid_out' },

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -213,7 +213,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     if (!prefs) {
       prefs = await getEnergyPreferences(this.hass);
     }
-    const showNetFlows = this.config.autoconfig?.show_net_flows !== false;
+    const netFlows = this.config.autoconfig?.net_flows !== false;
     const sources: typeof prefs.energy_sources = [];
     (prefs?.energy_sources || []).forEach(s => {
       if (!ENERGY_SOURCE_TYPES.includes(s.type)) {
@@ -271,7 +271,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const sections = [
       {
         entities: sources.map(source => {
-          const subtract = (source.type === 'grid' || source.type === 'battery') && !showNetFlows
+          const subtract = (source.type === 'grid' || source.type === 'battery') && !netFlows
             ? undefined
             : source.stat_energy_to
               ? [source.stat_energy_to]
@@ -304,7 +304,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           seenFlowTo.add(stat_energy_to);
           sections[1].entities.unshift({
             entity_id: stat_energy_to,
-            subtract_entities: showNetFlows ? importEntities : undefined,
+            subtract_entities: netFlows ? importEntities : undefined,
             type: 'entity',
             color: getEnergySourceColor(grid.type),
             children: [],
@@ -321,7 +321,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       // battery charging
       sections[1].entities.unshift({
         entity_id: battery.stat_energy_to,
-        subtract_entities: showNetFlows ? [battery.stat_energy_from] : undefined,
+        subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
         type: 'entity',
         color: getEnergySourceColor(battery.type),
         children: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
     print_yaml?: boolean;
     group_by_floor?: boolean;
     group_by_area?: boolean;
-    show_net_flows?: boolean;
+    net_flows?: boolean;
   };
   title?: string;
   sections?: SectionConfig[];


### PR DESCRIPTION
## Summary

- Adds `autoconfig.net_flows` option (defaults to `true` — no behavior change for existing users)
- Setting `net_flows: false` shows **gross energy flows** instead of net, making grid export and battery charge/discharge visible even for net importers

## Problem

In autoconfig mode, `subtract_entities` is applied to grid import/export and battery charge/discharge entities, showing only **net** flows. For users who are net importers (the majority of solar panel owners), grid export always displays as 0 and is invisible in the chart.

## Solution

Add `net_flows` option to autoconfig. When set to `false`, skips `subtract_entities` for grid and battery source/destination entities, showing gross flows:

- **Solar** splits visibly into Grid Export + Home Consumption
- **Grid Import** shows the full import value
- **Battery charge/discharge** shows gross values

The Sankey diagram balances correctly with gross flows.

### Usage

```yaml
autoconfig:
  net_flows: false  # show gross energy flows
```

Default behavior (`net_flows: true` or omitted) is unchanged from v3.10.2.

## Test plan

- [x] Existing autoconfig tests pass unchanged (default is net flows)
- [x] New test verifies `net_flows: false` removes `subtract_entities`
- [x] All 31 tests pass
- [x] Manually tested on a real HA instance with solar + battery + grid export