### PR TITLE
fix(#318): find energy collection by prefix instead of fixed key

### DIFF
--- a/src/energy.ts
+++ b/src/energy.ts
@@ -99,10 +99,14 @@ export interface EnergyCollection extends Collection<EnergyData> {
 
 export const getEnergyDataCollection = (
   hass: HomeAssistant,
-  key = '_energy'
 ): EnergyCollection | null => {
-  if ((hass.connection as any)[key]) {
-    return (hass.connection as any)[key];
+  if ((hass.connection as any)['_energy']) {
+    return (hass.connection as any)['_energy'];
+  }
+  for (const key of Object.keys(hass.connection)) {
+    if (key.startsWith('_energy') && typeof (hass.connection as any)[key]?.subscribe === 'function') {
+      return (hass.connection as any)[key];
+    }
   }
   // HA has not initialized the collection yet and we don't want to interfere with that if energy_date_selection is enabled
   return null;


### PR DESCRIPTION
## Summary
- In HA 2026.4, the `energy-date-selection` card stores its collection with a dashboard-URL-suffixed key (e.g., `_energy-/energy`) instead of `_energy`
- `getEnergyDataCollection` now searches for the first available `_energy*` collection on `hass.connection` instead of relying on a fixed key
- Backwards-compatible: tries the legacy `_energy` key first as a fast path

Fixes #318