### PR TITLE
feat: add autoconfig support for power

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ or like this:
 | group_by_floor    | boolean | **Optional** | true                | Display data per floor
 | group_by_area     | boolean | **Optional** | true                | Display data per area
 | net_flows         | boolean | **Optional** | true                | Show net energy flows. Set to `false` to show gross energy flows instead, making grid export and battery charge/discharge visible even for net importers
+| power             | boolean | **Optional** | false               | Use real-time power sensors if available (HA 2025.12+).
 
 ### Time Period
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ or like this:
 | group_by_floor    | boolean | **Optional** | true                | Display data per floor
 | group_by_area     | boolean | **Optional** | true                | Display data per area
 | net_flows         | boolean | **Optional** | true                | Show net energy flows. Set to `false` to show gross energy flows instead, making grid export and battery charge/discharge visible even for net importers
-| power             | boolean | **Optional** | false               | Use real-time power sensors if available (HA 2025.12+).
+| mode              | string  | **Optional** | energy              | Autoconfig mode. Valid options are `energy` (default) and `power` (requires HA 2025.12+).
 
 ### Time Period
 

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -625,4 +625,77 @@ describe('SankeyChart autoconfig', () => {
       expect(config.sections[3].sort_group_by_parent).toBe(true);
     });
   });
+
+  it('prefers power sensors when available and in power mode', async () => {
+    hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+    hass.states['sensor.solar_power'] = { entity_id: 'sensor.solar_power', state: '500' } as any;
+    hass.states['sensor.device1_power'] = { entity_id: 'sensor.device1_power', state: '300' } as any;
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { power: true } }, true);
+
+    (getEnergyPreferences as jest.Mock).mockResolvedValue({
+      energy_sources: [
+        {
+          type: 'grid',
+          stat_energy_from: 'sensor.grid_in',
+          stat_power_from: 'sensor.grid_power_in',
+        },
+        {
+          type: 'solar',
+          stat_energy_from: 'sensor.solar',
+          stat_power_from: 'sensor.solar_power',
+        },
+      ],
+      device_consumption: [
+        {
+          stat_consumption: 'sensor.device1',
+          stat_power_consumption: 'sensor.device1_power',
+          name: 'Device 1',
+        },
+      ],
+    });
+    (getEntitiesByArea as jest.Mock).mockResolvedValue({
+      area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.device1_power'] },
+    });
+    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sankeyChart as any)['autoconfig']();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (sankeyChart as any).config;
+
+    const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+    expect(allNodeIds).toContain('sensor.grid_power_in');
+    expect(allNodeIds).toContain('sensor.solar_power');
+    expect(allNodeIds).toContain('sensor.device1_power');
+    expect(allNodeIds).not.toContain('sensor.grid_in');
+    expect(allNodeIds).not.toContain('sensor.solar');
+    expect(allNodeIds).not.toContain('sensor.device1');
+  });
+
+  it('prefers energy sensors when power mode is disabled', async () => {
+    hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { power: false } }, true);
+
+    (getEnergyPreferences as jest.Mock).mockResolvedValue({
+      energy_sources: [
+        {
+          type: 'grid',
+          stat_energy_from: 'sensor.grid_in',
+          stat_power_from: 'sensor.grid_power_in',
+        },
+      ],
+      device_consumption: [],
+    });
+    (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sankeyChart as any)['autoconfig']();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (sankeyChart as any).config;
+
+    const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+    expect(allNodeIds).toContain('sensor.grid_in');
+    expect(allNodeIds).not.toContain('sensor.grid_power_in');
+  });
 });

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -630,7 +630,7 @@ describe('SankeyChart autoconfig', () => {
     hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
     hass.states['sensor.solar_power'] = { entity_id: 'sensor.solar_power', state: '500' } as any;
     hass.states['sensor.device1_power'] = { entity_id: 'sensor.device1_power', state: '300' } as any;
-    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { power: true } }, true);
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { mode: 'power' } }, true);
 
     (getEnergyPreferences as jest.Mock).mockResolvedValue({
       energy_sources: [
@@ -674,7 +674,7 @@ describe('SankeyChart autoconfig', () => {
 
   it('prefers energy sensors when power mode is disabled', async () => {
     hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
-    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { power: false } }, true);
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { mode: 'energy' } }, true);
 
     (getEnergyPreferences as jest.Mock).mockResolvedValue({
       energy_sources: [

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -626,7 +626,7 @@ describe('SankeyChart autoconfig', () => {
     });
   });
 
-  it('prefers power sensors when available and in power mode', async () => {
+  it('prefers power sensors when power mode is enabled', async () => {
     hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
     hass.states['sensor.solar_power'] = { entity_id: 'sensor.solar_power', state: '500' } as any;
     hass.states['sensor.device1_power'] = { entity_id: 'sensor.device1_power', state: '300' } as any;
@@ -637,18 +637,18 @@ describe('SankeyChart autoconfig', () => {
         {
           type: 'grid',
           stat_energy_from: 'sensor.grid_in',
-          stat_power_from: 'sensor.grid_power_in',
+          stat_rate: 'sensor.grid_power_in',
         },
         {
           type: 'solar',
           stat_energy_from: 'sensor.solar',
-          stat_power_from: 'sensor.solar_power',
+          stat_rate: 'sensor.solar_power',
         },
       ],
       device_consumption: [
         {
           stat_consumption: 'sensor.device1',
-          stat_power_consumption: 'sensor.device1_power',
+          stat_rate: 'sensor.device1_power',
           name: 'Device 1',
         },
       ],
@@ -681,7 +681,7 @@ describe('SankeyChart autoconfig', () => {
         {
           type: 'grid',
           stat_energy_from: 'sensor.grid_in',
-          stat_power_from: 'sensor.grid_power_in',
+          stat_rate: 'sensor.grid_power_in',
         },
       ],
       device_consumption: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2699,6 +2699,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2852,6 +2873,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/browserslist": {
       "version": "4.17.3",
@@ -3483,6 +3523,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -4280,6 +4328,17 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -6388,6 +6447,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-resolve": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.3.1.tgz",
@@ -6465,6 +6542,45 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/@types/yargs": {
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-util": {
@@ -7161,6 +7277,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
+      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object.values": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
@@ -7645,6 +7781,20 @@
       "dependencies": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "util.promisify": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
@@ -8756,6 +8906,24 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/util.promisify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
+      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "for-each": "^0.3.3",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -11001,6 +11169,21 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      }
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -11118,6 +11301,27 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "browserslist": {
@@ -11598,6 +11802,14 @@
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
       }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -12174,6 +12386,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "form-data": {
       "version": "4.0.0",
@@ -13724,6 +13947,59 @@
       "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true
     },
+    "jest-resolve": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        }
+      }
+    },
     "jest-resolve-dependencies": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.3.1.tgz",
@@ -14326,6 +14602,20 @@
         "has": "^1.0.3"
       }
     },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
+      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "array.prototype.reduce": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
     "object.values": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
@@ -14660,6 +14950,17 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
+      }
+    },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "util.promisify": "^1.0.0"
       }
     },
     "regexp.prototype.flags": {
@@ -15460,6 +15761,21 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "util.promisify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
+      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "for-each": "^0.3.3",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.1"
       }
     },
     "v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2699,27 +2699,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.reduce": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2873,25 +2852,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-resolve": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "resolve": "1.1.7"
-      }
-    },
-    "node_modules/browser-resolve/node_modules/resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/browserslist": {
       "version": "4.17.3",
@@ -3523,14 +3483,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -4328,17 +4280,6 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -6447,24 +6388,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-resolve": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "jest-pnp-resolver": "^1.2.1",
-        "realpath-native": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.3.1.tgz",
@@ -6542,45 +6465,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-util": {
@@ -7277,26 +7161,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "array.prototype.reduce": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
@@ -7781,20 +7645,6 @@
       "dependencies": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/realpath-native": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "util.promisify": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
@@ -8906,24 +8756,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/util.promisify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "for-each": "^0.3.3",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -11169,21 +11001,6 @@
         "es-abstract": "^1.19.0"
       }
     },
-    "array.prototype.reduce": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      }
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -11301,27 +11118,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "browser-resolve": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
       }
     },
     "browserslist": {
@@ -11802,14 +11598,6 @@
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
       }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -12386,17 +12174,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
     },
     "form-data": {
       "version": "4.0.0",
@@ -13947,59 +13724,6 @@
       "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true
     },
-    "jest-resolve": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "jest-pnp-resolver": "^1.2.1",
-        "realpath-native": "^1.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        }
-      }
-    },
     "jest-resolve-dependencies": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.3.1.tgz",
@@ -14602,20 +14326,6 @@
         "has": "^1.0.3"
       }
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "array.prototype.reduce": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
     "object.values": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
@@ -14950,17 +14660,6 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
-      }
-    },
-    "realpath-native": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "util.promisify": "^1.0.0"
       }
     },
     "regexp.prototype.flags": {
@@ -15761,21 +15460,6 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "util.promisify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "for-each": "^0.3.3",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.1"
       }
     },
     "v8-compile-cache": {

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -470,7 +470,8 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
         margin-bottom: 20px;
       }
       .autoconfig {
-        display: flex;
+        display: grid;
+        grid-template-columns: auto auto;
         justify-content: space-between;
         margin-bottom: 16px;
       }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -74,15 +74,16 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
     const target = ev.target;
     if (target.configValue) {
       if (typeof target.configValue === 'function') {
-        this._config = target.configValue(this._config, target.checked !== undefined ? target.checked : target.value);
-      } else if (target.value === '') {
+        const val = target.tagName === 'HA-SWITCH' ? target.checked : (ev.detail?.value ?? target.value);
+        this._config = target.configValue(this._config, val);
+      } else if ((ev.detail?.value ?? target.value) === '') {
         const tmpConfig = { ...this._config };
         delete tmpConfig[target.configValue];
         this._config = tmpConfig;
       } else {
         this._config = {
           ...this._config,
-          [target.configValue]: target.checked !== undefined ? target.checked : target.value,
+          [target.configValue]: target.tagName === 'HA-SWITCH' ? target.checked : (ev.detail?.value ?? target.value),
         };
       }
     } else {
@@ -241,47 +242,53 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
   }
 
   private _computeSchema() {
-    return [
-      // {
-      //   type: 'grid',
-      //   name: '',
-      //   schema: [
-      //     { name: 'autoconfig', selector: { boolean: {} } },
-      //     { name: 'autoconfig.print_yaml', selector: { boolean: {} } },
-      //   ],
-      // },
-      { name: 'title', selector: { text: {} } },
-      { name: 'energy_date_selection', selector: { boolean: {} } },
+    const isPowerMode = this._config?.autoconfig?.mode === 'power';
+
+    const schema: any[] = [{ name: 'title', selector: { text: {} } }];
+
+    if (!isPowerMode) {
+      schema.push({ name: 'energy_date_selection', selector: { boolean: {} } });
+    }
+
+    const gridSchema: any[] = [];
+    if (!isPowerMode) {
+      gridSchema.push(
+        { name: 'time_period_from', selector: { text: {} } },
+        { name: 'time_period_to', selector: { text: {} } },
+      );
+    }
+    
+    gridSchema.push(
+      { name: 'show_names', selector: { boolean: {} } },
+      { name: 'show_icons', selector: { boolean: {} } },
+      { name: 'show_states', selector: { boolean: {} } },
+      { name: 'show_units', selector: { boolean: {} } },
       {
-        type: 'grid',
-        name: '',
-        schema: [
-          { name: 'time_period_from', selector: { text: {} } },
-          { name: 'time_period_to', selector: { text: {} } },
-          { name: 'show_names', selector: { boolean: {} } },
-          { name: 'show_icons', selector: { boolean: {} } },
-          { name: 'show_states', selector: { boolean: {} } },
-          { name: 'show_units', selector: { boolean: {} } },
-          {
-            name: 'layout',
-            selector: {
-              select: {
-                mode: 'dropdown',
-                options: [
-                  { value: 'auto', label: localize('editor.layout.auto') },
-                  { value: 'horizontal', label: localize('editor.layout.horizontal') },
-                  { value: 'vertical', label: localize('editor.layout.vertical') },
-                ],
-              },
-            },
+        name: 'layout',
+        selector: {
+          select: {
+            mode: 'dropdown',
+            options: [
+              { value: 'auto', label: localize('editor.layout.auto') },
+              { value: 'horizontal', label: localize('editor.layout.horizontal') },
+              { value: 'vertical', label: localize('editor.layout.vertical') },
+            ],
           },
-          { name: 'wide', selector: { boolean: {} } },
-          { name: 'height', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
-          { name: 'min_box_size', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
-          { name: 'min_box_distance', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
-        ],
+        },
       },
-      {
+      { name: 'wide', selector: { boolean: {} } },
+      { name: 'height', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
+      { name: 'min_box_size', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
+      { name: 'min_box_distance', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
+    );
+
+    schema.push({
+      type: 'grid',
+      name: '',
+      schema: gridSchema,
+    });
+
+    schema.push({
         type: 'grid',
         name: '',
         schema: [
@@ -328,8 +335,9 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
           },
           { name: 'throttle', selector: { number: { mode: 'box', unit_of_measurement: 'ms' } } },
         ],
-      },
-    ];
+      }
+    );
+    return schema;
   }
 
   private _computeLabel = (schema: { name: string }) => {
@@ -369,7 +377,7 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
                 .configValue=${(conf, val: boolean) => {
                   const newConf = { ...conf };
                   if (val && !conf.autoconfig) {
-                    newConf.autoconfig = { print_yaml: false, power: false };
+                    newConf.autoconfig = { print_yaml: false };
                     // Clear manual config when enabling autoconfig
                     newConf.nodes = [];
                     newConf.links = [];
@@ -394,16 +402,32 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
                       @change=${this._valueChanged}
                     ></ha-switch>
                   </ha-formfield>
-                  <ha-formfield .label=${localize('editor.fields.autoconfig_power')}>
-                    <ha-switch
-                      .checked=${!!autoconfig?.power}
-                      .configValue=${(conf, power) => ({
-                        ...conf,
-                        autoconfig: { ...conf.autoconfig, power },
-                      })}
-                      @change=${this._valueChanged}
-                    ></ha-switch>
-                  </ha-formfield>
+                  <ha-form
+                    .hass=${this.hass}
+                    .data=${{ mode: autoconfig?.mode || 'energy' }}
+                    .configValue=${(conf, val) => ({
+                      ...conf,
+                      autoconfig: { ...conf.autoconfig, mode: val.mode }
+                    })}
+                    .schema=${[
+                      {
+                        name: 'mode',
+                        selector: {
+                          select: {
+                            mode: 'dropdown',
+                            options: [
+                              { value: 'energy', label: localize('editor.mode.energy') },
+                              { value: 'power', label: localize('editor.mode.power') },
+                            ],
+                          },
+                        },
+                      },
+                    ]}
+                    .computeLabel=${() => localize('editor.fields.autoconfig_mode')}
+                    @value-changed=${(ev: any) => {
+                      this._valueChanged(ev);
+                    }}
+                  ></ha-form>
                 `
               : nothing}
           </div>

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -369,7 +369,7 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
                 .configValue=${(conf, val: boolean) => {
                   const newConf = { ...conf };
                   if (val && !conf.autoconfig) {
-                    newConf.autoconfig = { print_yaml: false };
+                    newConf.autoconfig = { print_yaml: false, power: false };
                     // Clear manual config when enabling autoconfig
                     newConf.nodes = [];
                     newConf.links = [];
@@ -383,13 +383,28 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
               ></ha-switch>
             </ha-formfield>
             ${autoconfig
-              ? html`<ha-formfield .label=${localize('editor.fields.print_yaml')}>
-                  <ha-switch
-                    .checked=${!!autoconfig?.print_yaml}
-                    .configValue=${(conf, print_yaml) => ({ ...conf, autoconfig: { print_yaml } })}
-                    @change=${this._valueChanged}
-                  ></ha-switch>
-                </ha-formfield>`
+              ? html`
+                  <ha-formfield .label=${localize('editor.fields.print_yaml')}>
+                    <ha-switch
+                      .checked=${!!autoconfig?.print_yaml}
+                      .configValue=${(conf, print_yaml) => ({
+                        ...conf,
+                        autoconfig: { ...conf.autoconfig, print_yaml },
+                      })}
+                      @change=${this._valueChanged}
+                    ></ha-switch>
+                  </ha-formfield>
+                  <ha-formfield .label=${localize('editor.fields.autoconfig_power')}>
+                    <ha-switch
+                      .checked=${!!autoconfig?.power}
+                      .configValue=${(conf, power) => ({
+                        ...conf,
+                        autoconfig: { ...conf.autoconfig, power },
+                      })}
+                      @change=${this._valueChanged}
+                    ></ha-switch>
+                  </ha-formfield>
+                `
               : nothing}
           </div>
 

--- a/src/energy.ts
+++ b/src/energy.ts
@@ -62,17 +62,25 @@ export interface EnergySource {
   type: string;
   stat_energy_from?: string;
   stat_energy_to?: string;
+  stat_rate?: string;
+  power_config?: {
+    stat_rate_from?: string;
+    stat_rate_to?: string;
+  };
   flow_from?: {
     stat_energy_from: string;
+    stat_rate?: string;
   }[];
   flow_to?: {
     stat_energy_to: string;
+    stat_rate?: string;
   }[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DeviceConsumptionEnergyPreference {
   stat_consumption: string;
+  stat_rate?: string;
   name?: string;
   included_in_stat?: string;
 }

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -16,6 +16,7 @@ import {
   EnergyCollection,
   EnergyData,
   ENERGY_SOURCE_TYPES,
+  EnergySource,
   getEnergyDataCollection,
   getEnergySourceColor,
   getStatistics,
@@ -164,6 +165,8 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       getTimePeriod();
       const interval = setInterval(getTimePeriod, this.config.throttle || 1000);
       return [() => clearInterval(interval)];
+    } else if (isAutoconfig && !this.config.sections.length) {
+      this.autoconfig();
     }
     return [];
   }
@@ -207,21 +210,32 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       prefs = await getEnergyPreferences(this.hass);
     }
     const netFlows = this.config.autoconfig?.net_flows !== false;
-    const sources: typeof prefs.energy_sources = [];
-    (prefs?.energy_sources || []).forEach(s => {
+    const usePower = this.config.autoconfig?.power === true;
+
+    const sources: (EnergySource & { _autoconfig_id: string; _real_entity_id: string })[] = [];
+    for (const s of (prefs?.energy_sources || [])) {
       if (!ENERGY_SOURCE_TYPES.includes(s.type)) {
-        return;
+        continue;
       }
-      [s, ...(s.flow_from || [])].forEach(f => {
-        if (f.stat_energy_from) {
-          if (!this.hass.states[f.stat_energy_from]) {
-            console.warn('Ignoring missing entity ' + f.stat_energy_from);
+      for (const f of [s, ...(s.flow_from || [])]) {
+        let entityId = usePower ? (f.stat_rate || s.power_config?.stat_rate_from || f.stat_energy_from) : f.stat_energy_from;
+        if (!entityId && f === s && s.power_config) {
+          entityId = s.power_config.stat_rate_from || s.power_config.stat_rate_to;
+        }
+
+        if (entityId) {
+          if (!this.hass.states[entityId]) {
+            console.warn('Ignoring missing entity ' + entityId);
           } else {
-            sources.push({ ...s, ...f });
+            // Suffix source ID if it might conflict with child nodes later
+            const sourceId = (s.stat_energy_to || s.stat_rate || s.power_config?.stat_rate_to) === entityId
+              ? `source_${entityId}`
+              : entityId;
+            sources.push({ ...s, ...f, _autoconfig_id: sourceId, _real_entity_id: entityId });
           }
         }
-      });
-    });
+      }
+    }
     sources.sort((s1, s2) => {
       // sort to solar, battery, grid
       if (s1.type === s2.type) {
@@ -241,11 +255,24 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const links: Config['links'] = [];
     const sections: SectionConfig[] = [];
 
-    prefs.device_consumption.forEach((device, idx) => {
+    const energyToPowerDeviceMap: Record<string, string> = {};
+    for (const device of prefs.device_consumption) {
+      if (usePower && device.stat_rate) {
+        energyToPowerDeviceMap[device.stat_consumption] = device.stat_rate;
+      }
+    }
+
+    for (let idx = 0; idx < prefs.device_consumption.length; idx++) {
+      const device = prefs.device_consumption[idx];
+      const entityId = usePower && device.stat_rate ? device.stat_rate : device.stat_consumption;
+      let parent = device.included_in_stat;
+      if (usePower && parent && energyToPowerDeviceMap[parent]) {
+        parent = energyToPowerDeviceMap[parent];
+      }
       const node = {
-        id: device.stat_consumption,
+        id: entityId,
         name: device.name,
-        parent: device.included_in_stat,
+        parent: parent,
         color: `var(--color-${(idx % 54) + 1})`,
       };
       if (node.parent) {
@@ -257,30 +284,33 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         links.push({ source: node.parent, target: node.id });
       }
       deviceNodes.push(node);
-    });
+    }
     const devicesWithoutParent = deviceNodes.filter(node => !parentLinks[node.id]);
 
     let currentSection = 0;
 
     sources.forEach(source => {
-      if (!source.stat_energy_from) return;
+      const statPowerTo = usePower && (source.stat_rate || source.power_config?.stat_rate_to);
       const subtract = (source.type === 'grid' || source.type === 'battery') && !netFlows
         ? undefined
-        : source.stat_energy_to
-          ? [source.stat_energy_to]
-          : source.flow_to?.map(e => e.stat_energy_to).filter(Boolean) as string[] | undefined;
+        : statPowerTo
+          ? [statPowerTo]
+          : source.stat_energy_to
+            ? [source.stat_energy_to]
+            : source.flow_to?.map(e => (usePower ? e.stat_rate || e.stat_energy_to : e.stat_energy_to)).filter(Boolean) as
+                | string[]
+                | undefined;
       nodes.push({
-        id: source.stat_energy_from,
+        id: source._autoconfig_id,
+        entity_id: source._real_entity_id,
         section: currentSection,
         type: 'entity',
         name: '',
-        subtract_entities: subtract,
+        subtract_entities: subtract?.filter(id => id !== source._autoconfig_id && id !== source._real_entity_id),
         color: getEnergySourceColor(source.type),
       });
-      links.push({ source: source.stat_energy_from, target: TOTAL_NODE_ID });
     });
     sections.push({});
-
     currentSection++;
 
     nodes.push({
@@ -293,52 +323,77 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         reconcile_to: 'max',
       },
     });
-    links.push({ source: TOTAL_NODE_ID, target: UNKNOWN_NODE_ID });
 
     const gridSources = sources.filter(s => s.type === 'grid');
     const seenFlowTo = new Set<string>();
     gridSources.forEach(grid => {
-      const exportEntities = grid.flow_to?.map(e => e.stat_energy_to) ??
+      const exportEntities =
+        (usePower && (grid.stat_rate || grid.power_config?.stat_rate_to)
+          ? [grid.stat_rate || grid.power_config!.stat_rate_to!]
+          : undefined) ??
+        grid.flow_to?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_to)).filter(Boolean) ??
         (grid.stat_energy_to ? [grid.stat_energy_to] : []);
-      const importEntities = grid.flow_from?.map(e => e.stat_energy_from) ??
+      const importEntities =
+        (usePower && (grid.stat_rate || grid.power_config?.stat_rate_from)
+          ? [grid.stat_rate || grid.power_config!.stat_rate_from!]
+          : undefined) ??
+        grid.flow_from?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_from)).filter(Boolean) ??
         (grid.stat_energy_from ? [grid.stat_energy_from] : []);
       if (exportEntities.length) {
-        exportEntities.forEach(stat_energy_to => {
-          if (!stat_energy_to || seenFlowTo.has(stat_energy_to)) return;
-          seenFlowTo.add(stat_energy_to);
+        exportEntities.forEach(stat_to => {
+          if (!stat_to || seenFlowTo.has(stat_to)) return;
+          seenFlowTo.add(stat_to);
           nodes.push({
-            id: stat_energy_to,
+            id: stat_to,
             section: currentSection,
             type: 'entity',
             name: '',
-            subtract_entities: netFlows ? importEntities : undefined,
+            subtract_entities: netFlows ? importEntities.filter(id => id !== stat_to) : undefined,
             color: getEnergySourceColor(grid.type),
           });
+          // These are children of the source, same section as TOTAL_NODE_ID
           sources.forEach(source => {
-            if (!source.stat_energy_from) return;
-            links.push({ source: source.stat_energy_from, target: stat_energy_to });
+            if (source._autoconfig_id !== stat_to) {
+              links.push({ source: source._autoconfig_id, target: stat_to });
+            }
           });
         });
       }
     });
 
     const battery = sources.find(s => s.type === 'battery');
-    if (battery && battery.stat_energy_from && battery.stat_energy_to) {
-      nodes.push({
-        id: battery.stat_energy_to,
-        section: currentSection,
-        type: 'entity',
-        name: '',
-        subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
-        color: getEnergySourceColor(battery.type),
-      });
-      sources.forEach(source => {
-        if (!source.stat_energy_from) return;
-        links.push({ source: source.stat_energy_from, target: battery.stat_energy_to! });
-      });
+    if (battery) {
+      const battery_to =
+        usePower && (battery.stat_rate || battery.power_config?.stat_rate_to)
+          ? battery.stat_rate || battery.power_config!.stat_rate_to!
+          : battery.stat_energy_to;
+      if (battery_to) {
+        nodes.push({
+          id: battery_to,
+          section: currentSection,
+          type: 'entity',
+          name: '',
+            subtract_entities: netFlows
+              ? sources.filter(s => s._autoconfig_id !== battery_to && s._real_entity_id !== battery_to).map(s => s._autoconfig_id)
+              : undefined,
+          color: getEnergySourceColor(battery.type),
+        });
+        sources.forEach(source => {
+          if (source._autoconfig_id !== battery_to) {
+            links.push({ source: source._autoconfig_id, target: battery_to });
+          }
+        });
+      }
     }
-    sections.push({});
 
+    // Now link sources to Total Consumption
+    sources.forEach(source => {
+      if (source._autoconfig_id !== TOTAL_NODE_ID) {
+        links.push({ source: source._autoconfig_id, target: TOTAL_NODE_ID });
+      }
+    });
+
+    sections.push({});
     currentSection++;
 
     const groupByFloor = this.config.autoconfig?.group_by_floor !== false;
@@ -355,6 +410,12 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         entities.forEach(entityId => {
           areaByDeviceId[entityId] = area.area_id;
         });
+      });
+      const devicesByArea: Record<string, string[]> = {};
+      devicesWithoutParent.forEach(d => {
+        const areaId = areaByDeviceId[d.id] ?? NO_AREA;
+        if (!devicesByArea[areaId]) devicesByArea[areaId] = [];
+        devicesByArea[areaId].push(d.id);
       });
 
       // floorsMap mirrors HA's _groupByFloorAndArea. 'no_floor' is seeded
@@ -396,27 +457,50 @@ class SankeyChart extends SubscribeMixin(LitElement) {
 
       // HA never creates a "No area" node: no_area entities are wired
       // straight to the parent (floor or total).
-      const linkAreaOrEntities = (parentId: string, areaId: string) => {
-        const a = areasResult[areaId];
-        if (!a) return;
-        if (areaId === NO_AREA || !groupByArea) {
+      const linkAreaOrEntities = (parentId: string, areaId: string, section: number) => {
+        let a = areasResult[areaId];
+        if (areaId === NO_AREA) {
+          a = { area: { area_id: NO_AREA, name: 'Other Devices' } as any, entities: devicesByArea[NO_AREA] || [] };
+        }
+        if (!a || !a.entities.length) return;
+        if (areaId === NO_AREA && groupByArea) {
+          // Group unassigned devices into an 'Other Devices' box
+          const otherId = `${parentId}_other_devices`;
+          if (!nodes.some(n => n.id === otherId)) {
+            nodes.push({
+              id: otherId,
+              section: section,
+              type: 'remaining_child_state',
+              name: 'Other Devices',
+            });
+            links.push({ source: parentId, target: otherId });
+          }
+          a.entities.forEach(entityId => {
+            links.push({ source: otherId, target: entityId });
+          });
+        } else if (!groupByArea) {
           a.entities.forEach(entityId => {
             links.push({ source: parentId, target: entityId });
           });
         } else {
-          links.push({ source: parentId, target: areaId });
+          const areaNodeId = `${parentId}_${areaId}`;
+          nodes.push({
+            id: areaNodeId,
+            section: section,
+            type: 'remaining_child_state',
+            name: a.area.name,
+          });
+          links.push({ source: parentId, target: areaNodeId });
+          a.entities.forEach(entityId => {
+            links.push({ source: areaNodeId, target: entityId });
+          });
         }
       };
 
       if (groupByFloor && hasAnyRealFloor) {
+        // Section: Floors
         sortedFloorIds.forEach(floorId => {
-          if (floorId === NO_FLOOR) {
-            floorsMap[NO_FLOOR].areas.forEach(areaId => {
-              linkAreaOrEntities(TOTAL_NODE_ID, areaId);
-            });
-            return;
-          }
-
+          if (floorId === NO_FLOOR) return;
           const floor = floorsById[floorId];
           nodes.push({
             id: floorId,
@@ -425,62 +509,31 @@ class SankeyChart extends SubscribeMixin(LitElement) {
             name: floor?.name ?? floorId,
           });
           links.push({ source: TOTAL_NODE_ID, target: floorId });
+        });
+        sections.push({ sort_by: 'none', sort_group_by_parent: true });
+        currentSection++;
 
+        // Section: Areas
+        sortedFloorIds.forEach(floorId => {
+          const parentId = floorId === NO_FLOOR ? TOTAL_NODE_ID : floorId;
           floorsMap[floorId].areas.forEach(areaId => {
-            linkAreaOrEntities(floorId, areaId);
+            linkAreaOrEntities(parentId, areaId, currentSection);
           });
         });
-
-        sections.push({ sort_by: 'none' });
+        sections.push({ sort_by: 'none', sort_group_by_parent: true });
         currentSection++;
-      } else if (!groupByArea) {
+      } else if (groupByArea) {
+        // Section: Areas (no floors)
+        Object.keys(devicesByArea).forEach(areaId => {
+          linkAreaOrEntities(TOTAL_NODE_ID, areaId, currentSection);
+        });
+        sections.push({ sort_by: 'none', sort_group_by_parent: true });
+        currentSection++;
+      } else {
+        // No grouping
         devicesWithoutParent.forEach(d => {
           links.push({ source: TOTAL_NODE_ID, target: d.id });
         });
-      } else {
-        // Orphan-only path: no real floors, still grouping by area. Walk
-        // areas in the insertion order we built (no_floor first, then any
-        // leftovers from areasResult).
-        const emitted = new Set<string>();
-        floorsMap[NO_FLOOR].areas.forEach(areaId => {
-          if (!areasResult[areaId]) return;
-          linkAreaOrEntities(TOTAL_NODE_ID, areaId);
-          emitted.add(areaId);
-        });
-        Object.keys(areasResult).forEach(areaId => {
-          if (emitted.has(areaId)) return;
-          linkAreaOrEntities(TOTAL_NODE_ID, areaId);
-        });
-      }
-
-      if (groupByArea) {
-        const areaOrder: string[] = [];
-        sortedFloorIds.forEach(fId => {
-          floorsMap[fId].areas.forEach(aId => {
-            if (aId === NO_AREA) return;
-            if (!areaOrder.includes(aId) && areasResult[aId]) {
-              areaOrder.push(aId);
-            }
-          });
-        });
-
-        if (areaOrder.length) {
-          areaOrder.forEach(areaId => {
-            const a = areasResult[areaId];
-            if (!a) return;
-            nodes.push({
-              id: a.area.area_id,
-              section: currentSection,
-              type: 'remaining_child_state',
-              name: a.area.name,
-            });
-            a.entities.forEach(entityId => {
-              links.push({ source: a.area.area_id, target: entityId });
-            });
-          });
-          sections.push({ sort_by: 'none', sort_group_by_parent: true });
-          currentSection++;
-        }
       }
     } else {
       devicesWithoutParent.forEach(d => {
@@ -508,14 +561,16 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       }
     });
 
+    // Add the "Untracked" usage box as a sibling of floors
     const totalSection = nodes.find(n => n.id === TOTAL_NODE_ID)?.section;
     if (totalSection !== undefined) {
       nodes.push({
         id: UNKNOWN_NODE_ID,
         section: totalSection + 1,
         type: 'remaining_parent_state',
-        name: 'Unknown',
+        name: 'Untracked',
       });
+      links.push({ source: TOTAL_NODE_ID, target: UNKNOWN_NODE_ID });
     }
 
     // normalizeConfig() normally calls this, but setNormalizedConfig bypasses

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -210,7 +210,29 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       prefs = await getEnergyPreferences(this.hass);
     }
     const netFlows = this.config.autoconfig?.net_flows !== false;
-    const usePower = this.config.autoconfig?.power === true;
+    const mode = this.config.autoconfig?.mode || 'energy';
+
+    const ext = {
+      energy: {
+        getSourceEntityId: (s: any, f: any) => f.stat_energy_from,
+        getDeviceEntityId: (d: any) => d.stat_consumption,
+        getSourceSubtract: (s: any) => s.stat_energy_to ? [s.stat_energy_to] : s.flow_to?.map((e: any) => e.stat_energy_to).filter(Boolean),
+        getGridExportEntities: (grid: any) => grid.flow_to?.map((e: any) => e.stat_energy_to).filter(Boolean) ?? (grid.stat_energy_to ? [grid.stat_energy_to] : []),
+        getGridImportEntities: (grid: any) => grid.flow_from?.map((e: any) => e.stat_energy_from).filter(Boolean) ?? (grid.stat_energy_from ? [grid.stat_energy_from] : []),
+        getBatteryToEntityId: (battery: any) => battery.stat_energy_to,
+      },
+      power: {
+        getSourceEntityId: (s: any, f: any) => f.stat_rate || s.power_config?.stat_rate_from || f.stat_energy_from || (f === s && s.power_config ? s.power_config.stat_rate_to : undefined),
+        getDeviceEntityId: (d: any) => d.stat_rate || d.stat_consumption,
+        getSourceSubtract: (s: any) => {
+          const statPowerTo = s.stat_rate || s.power_config?.stat_rate_to;
+          return statPowerTo ? [statPowerTo] : (s.stat_energy_to ? [s.stat_energy_to] : s.flow_to?.map((e: any) => e.stat_rate || e.stat_energy_to).filter(Boolean));
+        },
+        getGridExportEntities: (grid: any) => (grid.power_config?.stat_rate_to ? [grid.power_config.stat_rate_to] : undefined) ?? grid.flow_to?.map((e: any) => (e.stat_rate || e.stat_energy_to)).filter(Boolean) ?? (grid.stat_energy_to ? [grid.stat_energy_to] : []),
+        getGridImportEntities: (grid: any) => (grid.power_config?.stat_rate_from ? [grid.power_config.stat_rate_from] : undefined) ?? grid.flow_from?.map((e: any) => (e.stat_rate || e.stat_energy_from)).filter(Boolean) ?? (grid.stat_energy_from ? [grid.stat_energy_from] : []),
+        getBatteryToEntityId: (battery: any) => battery.stat_rate || battery.power_config?.stat_rate_to || battery.stat_energy_to,
+      }
+    }[mode];
 
     const sources: (EnergySource & { _autoconfig_id: string; _real_entity_id: string })[] = [];
     for (const s of (prefs?.energy_sources || [])) {
@@ -218,10 +240,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         continue;
       }
       for (const f of [s, ...(s.flow_from || [])]) {
-        let entityId = usePower ? (f.stat_rate || s.power_config?.stat_rate_from || f.stat_energy_from) : f.stat_energy_from;
-        if (!entityId && f === s && s.power_config) {
-          entityId = s.power_config.stat_rate_from || s.power_config.stat_rate_to;
-        }
+        const entityId = ext.getSourceEntityId(s, f);
 
         if (entityId) {
           if (!this.hass.states[entityId]) {
@@ -255,19 +274,20 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const links: Config['links'] = [];
     const sections: SectionConfig[] = [];
 
-    const energyToPowerDeviceMap: Record<string, string> = {};
+    const deviceEntityIdMap: Record<string, string> = {};
     for (const device of prefs.device_consumption) {
-      if (usePower && device.stat_rate) {
-        energyToPowerDeviceMap[device.stat_consumption] = device.stat_rate;
+      const entityId = ext.getDeviceEntityId(device);
+      if (entityId) {
+        deviceEntityIdMap[device.stat_consumption] = entityId;
       }
     }
 
     for (let idx = 0; idx < prefs.device_consumption.length; idx++) {
       const device = prefs.device_consumption[idx];
-      const entityId = usePower && device.stat_rate ? device.stat_rate : device.stat_consumption;
+      const entityId = ext.getDeviceEntityId(device);
       let parent = device.included_in_stat;
-      if (usePower && parent && energyToPowerDeviceMap[parent]) {
-        parent = energyToPowerDeviceMap[parent];
+      if (parent && deviceEntityIdMap[parent]) {
+        parent = deviceEntityIdMap[parent];
       }
       const node = {
         id: entityId,
@@ -290,16 +310,9 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     let currentSection = 0;
 
     sources.forEach(source => {
-      const statPowerTo = usePower && (source.stat_rate || source.power_config?.stat_rate_to);
       const subtract = (source.type === 'grid' || source.type === 'battery') && !netFlows
         ? undefined
-        : statPowerTo
-          ? [statPowerTo]
-          : source.stat_energy_to
-            ? [source.stat_energy_to]
-            : source.flow_to?.map(e => (usePower ? e.stat_rate || e.stat_energy_to : e.stat_energy_to)).filter(Boolean) as
-                | string[]
-                | undefined;
+        : ext.getSourceSubtract(source) as string[] | undefined;
       nodes.push({
         id: source._autoconfig_id,
         entity_id: source._real_entity_id,
@@ -327,18 +340,8 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const gridSources = sources.filter(s => s.type === 'grid');
     const seenFlowTo = new Set<string>();
     gridSources.forEach(grid => {
-      const exportEntities =
-        (usePower && grid.power_config?.stat_rate_to
-          ? [grid.power_config.stat_rate_to]
-          : undefined) ??
-        grid.flow_to?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_to)).filter(Boolean) ??
-        (grid.stat_energy_to ? [grid.stat_energy_to] : []);
-      const importEntities =
-        (usePower && grid.power_config?.stat_rate_from
-          ? [grid.power_config.stat_rate_from]
-          : undefined) ??
-        grid.flow_from?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_from)).filter(Boolean) ??
-        (grid.stat_energy_from ? [grid.stat_energy_from] : []);
+      const exportEntities = ext.getGridExportEntities(grid);
+      const importEntities = ext.getGridImportEntities(grid);
       if (exportEntities.length) {
         exportEntities.forEach(stat_to => {
           if (!stat_to || seenFlowTo.has(stat_to)) return;
@@ -363,10 +366,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
 
     const battery = sources.find(s => s.type === 'battery');
     if (battery) {
-      const battery_to =
-        usePower && (battery.stat_rate || battery.power_config?.stat_rate_to)
-          ? battery.stat_rate || battery.power_config!.stat_rate_to!
-          : battery.stat_energy_to;
+      const battery_to = ext.getBatteryToEntityId(battery);
       if (battery_to) {
         nodes.push({
           id: battery_to,

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -228,7 +228,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
             console.warn('Ignoring missing entity ' + entityId);
           } else {
             // Suffix source ID if it might conflict with child nodes later
-            const sourceId = (s.stat_energy_to || s.stat_rate || s.power_config?.stat_rate_to) === entityId
+            const sourceId = (s.stat_energy_to || s.power_config?.stat_rate_to) === entityId
               ? `source_${entityId}`
               : entityId;
             sources.push({ ...s, ...f, _autoconfig_id: sourceId, _real_entity_id: entityId });
@@ -328,14 +328,14 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const seenFlowTo = new Set<string>();
     gridSources.forEach(grid => {
       const exportEntities =
-        (usePower && (grid.stat_rate || grid.power_config?.stat_rate_to)
-          ? [grid.stat_rate || grid.power_config!.stat_rate_to!]
+        (usePower && grid.power_config?.stat_rate_to
+          ? [grid.power_config.stat_rate_to]
           : undefined) ??
         grid.flow_to?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_to)).filter(Boolean) ??
         (grid.stat_energy_to ? [grid.stat_energy_to] : []);
       const importEntities =
-        (usePower && (grid.stat_rate || grid.power_config?.stat_rate_from)
-          ? [grid.stat_rate || grid.power_config!.stat_rate_from!]
+        (usePower && grid.power_config?.stat_rate_from
+          ? [grid.power_config.stat_rate_from]
           : undefined) ??
         grid.flow_from?.map(e => (usePower && e.stat_rate ? e.stat_rate : e.stat_energy_from)).filter(Boolean) ??
         (grid.stat_energy_from ? [grid.stat_energy_from] : []);
@@ -373,9 +373,9 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           section: currentSection,
           type: 'entity',
           name: '',
-            subtract_entities: netFlows
-              ? sources.filter(s => s._autoconfig_id !== battery_to && s._real_entity_id !== battery_to).map(s => s._autoconfig_id)
-              : undefined,
+          subtract_entities: netFlows
+            ? sources.filter(s => s._autoconfig_id !== battery_to && s._real_entity_id !== battery_to).map(s => s._autoconfig_id)
+            : undefined,
           color: getEnergySourceColor(battery.type),
         });
         sources.forEach(source => {
@@ -463,38 +463,30 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           a = { area: { area_id: NO_AREA, name: 'Other Devices' } as any, entities: devicesByArea[NO_AREA] || [] };
         }
         if (!a || !a.entities.length) return;
-        if (areaId === NO_AREA && groupByArea) {
-          // Group unassigned devices into an 'Other Devices' box
-          const otherId = `${parentId}_other_devices`;
-          if (!nodes.some(n => n.id === otherId)) {
-            nodes.push({
-              id: otherId,
-              section: section,
-              type: 'remaining_child_state',
-              name: 'Other Devices',
-            });
-            links.push({ source: parentId, target: otherId });
-          }
+        if (areaId === NO_AREA) {
+          // No area: wire entities directly to the parent (floor or total).
+          // autoRouteCrossGapLinks will insert passthrough nodes if needed.
           a.entities.forEach(entityId => {
-            links.push({ source: otherId, target: entityId });
+            links.push({ source: parentId, target: entityId });
           });
         } else if (!groupByArea) {
           a.entities.forEach(entityId => {
             links.push({ source: parentId, target: entityId });
           });
         } else {
-          const areaNodeId = `${parentId}_${areaId}`;
           nodes.push({
-            id: areaNodeId,
+            id: areaId,
             section: section,
             type: 'remaining_child_state',
             name: a.area.name,
           });
-          links.push({ source: parentId, target: areaNodeId });
+          links.push({ source: parentId, target: areaId });
           a.entities.forEach(entityId => {
-            links.push({ source: areaNodeId, target: entityId });
+            links.push({ source: areaId, target: entityId });
           });
+          return true; // signal that an area node was emitted
         }
+        return false;
       };
 
       if (groupByFloor && hasAnyRealFloor) {
@@ -524,11 +516,14 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         currentSection++;
       } else if (groupByArea) {
         // Section: Areas (no floors)
+        let anyArea = false;
         Object.keys(devicesByArea).forEach(areaId => {
-          linkAreaOrEntities(TOTAL_NODE_ID, areaId, currentSection);
+          if (linkAreaOrEntities(TOTAL_NODE_ID, areaId, currentSection)) anyArea = true;
         });
-        sections.push({ sort_by: 'none', sort_group_by_parent: true });
-        currentSection++;
+        if (anyArea) {
+          sections.push({ sort_by: 'none', sort_group_by_parent: true });
+          currentSection++;
+        }
       } else {
         // No grouping
         devicesWithoutParent.forEach(d => {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -22,7 +22,7 @@
       "time_period_from": "Time period from",
       "time_period_to": "Time period to",
       "autoconfig": "Autoconfig",
-      "autoconfig_power": "Use real-time power if available (HA 2025.12+)",
+      "autoconfig_mode": "Tracking mode (HA 2025.12+ for power)",
       "print_yaml": "Print auto generated config yaml",
       "layout": "Layout",
       "show_names": "Show names",
@@ -79,6 +79,10 @@
       "auto": "Auto",
       "vertical": "Vertical",
       "horizontal": "Horizontal"
+    },
+    "mode": {
+      "energy": "Energy",
+      "power": "Power"
     }
   }
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -22,6 +22,7 @@
       "time_period_from": "Time period from",
       "time_period_to": "Time period to",
       "autoconfig": "Autoconfig",
+      "autoconfig_power": "Use real-time power if available (HA 2025.12+)",
       "print_yaml": "Print auto generated config yaml",
       "layout": "Layout",
       "show_names": "Show names",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -22,7 +22,7 @@
       "time_period_from": "Time period from",
       "time_period_to": "Time period to",
       "autoconfig": "Autoconfig",
-      "autoconfig_mode": "Tracking mode (HA 2025.12+ for power)",
+      "autoconfig_mode": "Autoconfig mode",
       "print_yaml": "Print auto generated config yaml",
       "layout": "Layout",
       "show_names": "Show names",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -19,6 +19,7 @@
     "section_options": "Opções",
     "fields": {
       "autoconfig": "Auto-configurar",
+      "autoconfig_power": "Usar potência em tempo real se disponível (HA 2025.12+)",
       "print_yaml": "Imprimir yaml da configuração gerada automaticamente",
       "layout": "Layout",
       "show_names": "Mostrar nomes",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -19,7 +19,7 @@
     "section_options": "Opções",
     "fields": {
       "autoconfig": "Auto-configurar",
-      "autoconfig_mode": "Modo de rastreamento (HA 2025.12+ para potência)",
+      "autoconfig_mode": "Modo Autoconfig",
       "print_yaml": "Imprimir yaml da configuração gerada automaticamente",
       "layout": "Layout",
       "show_names": "Mostrar nomes",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -19,7 +19,7 @@
     "section_options": "Opções",
     "fields": {
       "autoconfig": "Auto-configurar",
-      "autoconfig_power": "Usar potência em tempo real se disponível (HA 2025.12+)",
+      "autoconfig_mode": "Modo de rastreamento (HA 2025.12+ para potência)",
       "print_yaml": "Imprimir yaml da configuração gerada automaticamente",
       "layout": "Layout",
       "show_names": "Mostrar nomes",
@@ -76,6 +76,10 @@
       "auto": "Automático",
       "vertical": "Vertical",
       "horizontal": "Horizontal"
+    },
+    "mode": {
+      "energy": "Energia",
+      "power": "Potência"
     }
   }
 }

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -9,7 +9,7 @@ export interface V3Config extends LovelaceCardConfig {
     group_by_floor?: boolean;
     group_by_area?: boolean;
     net_flows?: boolean;
-    power?: boolean;
+    mode?: 'energy' | 'power';
   };
   title?: string;
   sections?: V3SectionConfig[];

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -8,6 +8,8 @@ export interface V3Config extends LovelaceCardConfig {
     print_yaml?: boolean;
     group_by_floor?: boolean;
     group_by_area?: boolean;
+    net_flows?: boolean;
+    power?: boolean;
   };
   title?: string;
   sections?: V3SectionConfig[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
     group_by_floor?: boolean;
     group_by_area?: boolean;
     net_flows?: boolean;
+    power?: boolean;
   };
   title?: string;
   convert_units_to?: '' | CONVERSION_UNITS;
@@ -68,6 +69,7 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
 
 export interface Node {
   id: string;
+  entity_id?: string;
   section?: number; // index in sections array
   type?: NodeType;
   name?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
     group_by_floor?: boolean;
     group_by_area?: boolean;
     net_flows?: boolean;
-    power?: boolean;
+    mode?: 'energy' | 'power';
   };
   title?: string;
   convert_units_to?: '' | CONVERSION_UNITS;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,7 +245,7 @@ export function normalizeConfig(conf: SankeyChartConfig | V3Config, isMetric?: b
 
   const { autoconfig } = conf;
   if (autoconfig || typeof autoconfig === 'object') {
-    const isPower = typeof autoconfig === 'object' && autoconfig.power === true;
+    const isPower = typeof autoconfig === 'object' && autoconfig.mode === 'power';
     config = {
       ...config,
       energy_date_selection: config.energy_date_selection ?? (!config.time_period_from && !isPower && !config.energy_collection_key),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,7 +126,9 @@ function getUOMPrefix(unit_of_measurement: string): string {
 }
 
 export function getEntityId(entity: string | Node | Record<string, unknown>): string {
-  return typeof entity === 'string' ? entity : ((entity.id || (entity as Record<string, unknown>).entity_id) as string);
+  return typeof entity === 'string'
+    ? entity
+    : (((entity as Node).entity_id || (entity as Node).id || (entity as Record<string, unknown>).entity_id) as string);
 }
 
 export function getChildConnections(
@@ -243,11 +245,12 @@ export function normalizeConfig(conf: SankeyChartConfig | V3Config, isMetric?: b
 
   const { autoconfig } = conf;
   if (autoconfig || typeof autoconfig === 'object') {
+    const isPower = typeof autoconfig === 'object' && autoconfig.power === true;
     config = {
-      energy_date_selection: !config.time_period_from,
-      unit_prefix: 'k',
-      round: 1,
       ...config,
+      energy_date_selection: config.energy_date_selection ?? (!config.time_period_from && !isPower && !config.energy_collection_key),
+      unit_prefix: config.unit_prefix ?? (isPower ? '' : 'k'),
+      round: config.round ?? 1,
       nodes: config.nodes || [],
       links: config.links || [],
     };


### PR DESCRIPTION
Fixes #205 

Home Assistant 2025.12 extended the energy dashboard to track real-time power consumption via dedicated power sensors (stat_rate on sources and devices, power_config on grid sources). This PR adds support for those sensors in the autoconfig feature so users can get a live-updating power Sankey chart alongside the existing energy one.

How it was tested:
- Added 2 test-cases
- Uploaded dist js to Home Assistant (`/config/www directory`), disabled hacs ha-sankey-chart javascript and added my own (`/local/ha-sankey-chart.js`), and compared the output of `print_yaml: true` for both the energy and power autoconfig.