### PR TITLE
feat!: add autoconfig mode option (energy/power/water/water_flow) - requires 2025.12 or later depending on the mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ or like this:
 
 | Name              | Type    | Requirement  | Default             | Description                                 |
 | ----------------- | ------- | ------------ | ------------------- | ------------------------------------------- |
+| mode              | string  | **Optional** | `energy`            | One of `energy`, `power`, `water`, `water_flow`. `power` and `water_flow` are real-time and require HA 2025.12+ (they use the `stat_rate` fields exposed by the energy dashboard).
 | print_yaml        | boolean | **Optional** | false               | Prints the auto generated configuration after the card so you can use it as a starting point for customization. It shows up like an error. Don't worry about it.
 | group_by_floor    | boolean | **Optional** | true                | Display data per floor
 | group_by_area     | boolean | **Optional** | true                | Display data per area

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -69,41 +69,6 @@ describe('SankeyChart autoconfig', () => {
     });
   });
 
-  it('creates grid export entity for old format with flow_to', async () => {
-    hass.states['sensor.grid_out'] = { entity_id: 'sensor.grid_out', state: '3' } as any;
-    (getEnergyPreferences as jest.Mock).mockResolvedValue({
-      energy_sources: [
-        {
-          type: 'grid',
-          flow_from: [{ stat_energy_from: 'sensor.grid_in' }],
-          flow_to: [{ stat_energy_to: 'sensor.grid_out' }],
-        },
-        { type: 'solar', stat_energy_from: 'sensor.solar' },
-      ],
-      device_consumption: [
-        { stat_consumption: 'sensor.device1', name: 'Device 1' },
-      ],
-    });
-    (getEntitiesByArea as jest.Mock).mockResolvedValue({
-      area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.device1'] },
-    });
-    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (sankeyChart as any)['autoconfig']();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config = (sankeyChart as any).config;
-    const gridExport = config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_out');
-    expect(gridExport).toBeDefined();
-    expect(gridExport.subtract_entities).toEqual(['sensor.grid_in']);
-    // all source entities should link to grid export
-    const sourceNodes = config.nodes.filter((n: { id: string }) => ['sensor.grid_in', 'sensor.solar'].includes(n.id));
-    sourceNodes.forEach((n: { id: string }) => {
-      const link = config.links.find((l: { source: string; target: string }) => l.source === n.id && l.target === 'sensor.grid_out');
-      expect(link).toBeDefined();
-    });
-  });
-
   it('removes subtract_entities with net_flows: false', async () => {
     hass.states['sensor.grid_out'] = { entity_id: 'sensor.grid_out', state: '3' } as any;
     sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { net_flows: false } }, true);
@@ -623,6 +588,249 @@ describe('SankeyChart autoconfig', () => {
       expect(config.sections[2].sort_group_by_parent).toBe(true);
       expect(config.sections[3].sort_by).toBe('state');
       expect(config.sections[3].sort_group_by_parent).toBe(true);
+    });
+  });
+
+  describe('autoconfig.mode', () => {
+    // setConfig defaults: skip the DEFAULT_CONFIG spread so the
+    // mode-aware defaults actually apply (DEFAULT_CONFIG hardcodes unit_prefix='').
+    const setConfigMode = (mode?: 'energy' | 'power' | 'water' | 'water_flow') => {
+      sankeyChart.setConfig({ type: 'custom:ha-sankey-chart', autoconfig: mode ? { mode } : {} } as any, true);
+    };
+
+    it('mode=energy (default): unit_prefix=k and energy_date_selection=true', () => {
+      setConfigMode();
+      const config = (sankeyChart as any).config;
+      expect(config.unit_prefix).toBe('k');
+      expect(config.energy_date_selection).toBe(true);
+    });
+
+    it('mode=power: uses stat_rate for sources and devices, sets unit_prefix= and energy_date_selection=false', async () => {
+      hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+      hass.states['sensor.solar_power'] = { entity_id: 'sensor.solar_power', state: '500' } as any;
+      hass.states['sensor.device1_power'] = { entity_id: 'sensor.device1_power', state: '300' } as any;
+      setConfigMode('power');
+
+      let config = (sankeyChart as any).config;
+      expect(config.unit_prefix).toBe('');
+      expect(config.energy_date_selection).toBe(false);
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_rate: 'sensor.grid_power_in' },
+          { type: 'solar', stat_energy_from: 'sensor.solar', stat_rate: 'sensor.solar_power' },
+        ],
+        device_consumption: [
+          { stat_consumption: 'sensor.device1', stat_rate: 'sensor.device1_power', name: 'Device 1' },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({
+        area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.device1_power'] },
+      });
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      config = (sankeyChart as any).config;
+
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.grid_power_in');
+      expect(allNodeIds).toContain('sensor.solar_power');
+      expect(allNodeIds).toContain('sensor.device1_power');
+      expect(allNodeIds).not.toContain('sensor.grid_in');
+      expect(allNodeIds).not.toContain('sensor.solar');
+      expect(allNodeIds).not.toContain('sensor.device1');
+      // No separate to-side export node in rate mode (signed stat_rate covers both directions).
+      expect(allNodeIds).not.toContain('sensor.grid_out');
+    });
+
+    it('mode=power: remaps included_in_stat (parent stat_consumption) to parent stat_rate', async () => {
+      hass.states['sensor.basement_power'] = { entity_id: 'sensor.basement_power', state: '200' } as any;
+      hass.states['sensor.aux_charger_power'] = { entity_id: 'sensor.aux_charger_power', state: '50' } as any;
+      hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+      setConfigMode('power');
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_rate: 'sensor.grid_power_in' },
+        ],
+        device_consumption: [
+          { stat_consumption: 'sensor.basement_energy', stat_rate: 'sensor.basement_power', name: 'Basement' },
+          {
+            stat_consumption: 'sensor.aux_charger_energy',
+            stat_rate: 'sensor.aux_charger_power',
+            included_in_stat: 'sensor.basement_energy',
+            name: 'Aux Charger',
+          },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      const config = (sankeyChart as any).config;
+
+      // The parent→child link must reference the parent's stat_rate (its node id
+      // in power mode), not its stat_consumption (which is not a node).
+      const parentLink = config.links.find(
+        (l: { source: string; target: string }) =>
+          l.source === 'sensor.basement_power' && l.target === 'sensor.aux_charger_power',
+      );
+      expect(parentLink).toBeDefined();
+      const orphanLink = config.links.find(
+        (l: { source: string; target: string }) => l.source === 'sensor.basement_energy',
+      );
+      expect(orphanLink).toBeUndefined();
+    });
+
+    it('mode=power: orphans children when parent device has no stat_rate', async () => {
+      hass.states['sensor.tile_power'] = { entity_id: 'sensor.tile_power', state: '50' } as any;
+      hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+      setConfigMode('power');
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_rate: 'sensor.grid_power_in' },
+        ],
+        device_consumption: [
+          // Parent has no stat_rate → skipped in power mode.
+          { stat_consumption: 'sensor.1st_floor_energy', name: '1st Floor' },
+          // Child references the skipped parent → must orphan, not dangle.
+          {
+            stat_consumption: 'sensor.tile_energy',
+            stat_rate: 'sensor.tile_power',
+            included_in_stat: 'sensor.1st_floor_energy',
+            name: 'Tile',
+          },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({
+        area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.tile_power'] },
+      });
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      const config = (sankeyChart as any).config;
+
+      // No link should reference the (skipped) parent's stat_consumption.
+      const danglingLink = config.links.find(
+        (l: { source: string; target: string }) => l.source === 'sensor.1st_floor_energy',
+      );
+      expect(danglingLink).toBeUndefined();
+      // The child still appears as a node; floor/area routing wires it to TOTAL.
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.tile_power');
+      expect(allNodeIds).not.toContain('sensor.1st_floor_energy');
+    });
+
+    it('mode=power: silently skips devices/sources missing stat_rate', async () => {
+      hass.states['sensor.solar_power'] = { entity_id: 'sensor.solar_power', state: '500' } as any;
+      hass.states['sensor.device1_power'] = { entity_id: 'sensor.device1_power', state: '300' } as any;
+      setConfigMode('power');
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          // grid has no stat_rate — skipped
+          { type: 'grid', stat_energy_from: 'sensor.grid_in' },
+          { type: 'solar', stat_energy_from: 'sensor.solar', stat_rate: 'sensor.solar_power' },
+        ],
+        device_consumption: [
+          // device2 has no stat_rate — skipped
+          { stat_consumption: 'sensor.device2', name: 'Device 2' },
+          { stat_consumption: 'sensor.device1', stat_rate: 'sensor.device1_power', name: 'Device 1' },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({
+        area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.device1_power'] },
+      });
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      const config = (sankeyChart as any).config;
+
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.solar_power');
+      expect(allNodeIds).toContain('sensor.device1_power');
+      expect(allNodeIds).not.toContain('sensor.grid_in');
+      expect(allNodeIds).not.toContain('sensor.device2');
+    });
+
+    it('mode=water: filters type=water sources and pulls devices from device_consumption_water', async () => {
+      hass.states['sensor.water_meter'] = { entity_id: 'sensor.water_meter', state: '120' } as any;
+      hass.states['sensor.shower'] = { entity_id: 'sensor.shower', state: '15' } as any;
+      setConfigMode('water');
+
+      let config = (sankeyChart as any).config;
+      expect(config.unit_prefix).toBe('');
+      expect(config.energy_date_selection).toBe(true);
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'grid', stat_energy_from: 'sensor.grid_in' },
+          { type: 'water', stat_energy_from: 'sensor.water_meter' },
+        ],
+        device_consumption: [
+          { stat_consumption: 'sensor.device1', name: 'Device 1' },
+        ],
+        device_consumption_water: [
+          { stat_consumption: 'sensor.shower', name: 'Shower' },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({
+        area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.shower'] },
+      });
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      config = (sankeyChart as any).config;
+
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.water_meter');
+      expect(allNodeIds).toContain('sensor.shower');
+      // grid source ignored — wrong type for water mode
+      expect(allNodeIds).not.toContain('sensor.grid_in');
+      // device_consumption ignored — water mode reads device_consumption_water only
+      expect(allNodeIds).not.toContain('sensor.device1');
+    });
+
+    it('mode=water_flow: requires stat_rate on water source and device_consumption_water', async () => {
+      hass.states['sensor.water_flow_rate'] = { entity_id: 'sensor.water_flow_rate', state: '5' } as any;
+      hass.states['sensor.shower_rate'] = { entity_id: 'sensor.shower_rate', state: '2' } as any;
+      setConfigMode('water_flow');
+
+      let config = (sankeyChart as any).config;
+      expect(config.unit_prefix).toBe('');
+      expect(config.energy_date_selection).toBe(false);
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          // No stat_rate — skipped
+          { type: 'water', stat_energy_from: 'sensor.water_meter_2' },
+          { type: 'water', stat_energy_from: 'sensor.water_meter', stat_rate: 'sensor.water_flow_rate' },
+        ],
+        device_consumption: [
+          { stat_consumption: 'sensor.device1', stat_rate: 'sensor.device1_power', name: 'Device 1' },
+        ],
+        device_consumption_water: [
+          // No stat_rate — skipped
+          { stat_consumption: 'sensor.toilet', name: 'Toilet' },
+          { stat_consumption: 'sensor.shower', stat_rate: 'sensor.shower_rate', name: 'Shower' },
+        ],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({
+        area1: { area: { area_id: 'area1', name: 'Area 1' }, entities: ['sensor.shower_rate'] },
+      });
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      config = (sankeyChart as any).config;
+
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.water_flow_rate');
+      expect(allNodeIds).toContain('sensor.shower_rate');
+      expect(allNodeIds).not.toContain('sensor.water_meter');
+      expect(allNodeIds).not.toContain('sensor.water_meter_2');
+      expect(allNodeIds).not.toContain('sensor.toilet');
+      expect(allNodeIds).not.toContain('sensor.device1_power');
     });
   });
 });

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -5,7 +5,7 @@ import { HomeAssistant, fireEvent, LovelaceCardEditor, LovelaceConfig } from 'cu
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { customElement, property, state } from 'lit/decorators';
 import { repeat } from 'lit/directives/repeat';
-import { SankeyChartConfig, Section, SectionConfig, Node, NodeConfigForEditor } from '../types';
+import { AutoconfigMode, SankeyChartConfig, Section, SectionConfig, Node, NodeConfigForEditor } from '../types';
 import { localize } from '../localize/localize';
 import { normalizeConfig, convertNodesToSections } from '../utils';
 import './section';
@@ -383,13 +383,35 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
               ></ha-switch>
             </ha-formfield>
             ${autoconfig
-              ? html`<ha-formfield .label=${localize('editor.fields.print_yaml')}>
-                  <ha-switch
-                    .checked=${!!autoconfig?.print_yaml}
-                    .configValue=${(conf, print_yaml) => ({ ...conf, autoconfig: { print_yaml } })}
-                    @change=${this._valueChanged}
-                  ></ha-switch>
-                </ha-formfield>`
+              ? html`
+                  <ha-select
+                    .label=${localize('editor.fields.autoconfig_mode')}
+                    .value=${autoconfig?.mode || 'energy'}
+                    .options=${[
+                      { value: 'energy', label: localize('editor.autoconfig_mode.energy') },
+                      { value: 'power', label: localize('editor.autoconfig_mode.power') },
+                      { value: 'water', label: localize('editor.autoconfig_mode.water') },
+                      { value: 'water_flow', label: localize('editor.autoconfig_mode.water_flow') },
+                    ]}
+                    @selected=${(ev: CustomEvent<{ value: AutoconfigMode }>) => {
+                      this._config = {
+                        ...this._config!,
+                        autoconfig: { ...this._config!.autoconfig, mode: ev.detail.value },
+                      };
+                      fireEvent(this, 'config-changed', { config: this._config });
+                    }}
+                  ></ha-select>
+                  <ha-formfield .label=${localize('editor.fields.print_yaml')}>
+                    <ha-switch
+                      .checked=${!!autoconfig?.print_yaml}
+                      .configValue=${(conf, print_yaml: boolean) => ({
+                        ...conf,
+                        autoconfig: { ...conf.autoconfig, print_yaml },
+                      })}
+                      @change=${this._valueChanged}
+                    ></ha-switch>
+                  </ha-formfield>
+                `
               : nothing}
           </div>
 

--- a/src/energy.ts
+++ b/src/energy.ts
@@ -4,8 +4,13 @@ import { HomeAssistant } from "custom-card-helpers";
 import { Collection } from "home-assistant-js-websocket";
 import { differenceInDays } from 'date-fns';
 import { FT3_PER_M3 } from './const';
+import type { AutoconfigMode } from './types';
 
-export const ENERGY_SOURCE_TYPES = ['grid', 'solar', 'battery'];
+export const sourceTypesForMode = (mode: AutoconfigMode): string[] =>
+  mode === 'water' || mode === 'water_flow' ? ['water'] : ['grid', 'solar', 'battery'];
+
+export const isRateMode = (mode: AutoconfigMode): boolean =>
+  mode === 'power' || mode === 'water_flow';
 
 export interface EnergyData {
   start: Date;
@@ -62,17 +67,12 @@ export interface EnergySource {
   type: string;
   stat_energy_from?: string;
   stat_energy_to?: string;
-  flow_from?: {
-    stat_energy_from: string;
-  }[];
-  flow_to?: {
-    stat_energy_to: string;
-  }[];
+  stat_rate?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DeviceConsumptionEnergyPreference {
   stat_consumption: string;
+  stat_rate?: string;
   name?: string;
   included_in_stat?: string;
 }
@@ -80,6 +80,7 @@ export interface DeviceConsumptionEnergyPreference {
 export interface EnergyPreferences {
   energy_sources: EnergySource[];
   device_consumption: DeviceConsumptionEnergyPreference[];
+  device_consumption_water?: DeviceConsumptionEnergyPreference[];
 }
 
 export interface EnergyInfo {
@@ -357,6 +358,9 @@ export function getEnergySourceColor(type: string) {
   }
   if (type === 'battery') {
     return 'var(--success-color)';
+  }
+  if (type === 'water') {
+    return 'var(--info-color)';
   }
   return undefined;
 }

--- a/src/energy.ts
+++ b/src/energy.ts
@@ -352,15 +352,18 @@ export async function getStatistics(hass: HomeAssistant, { start, end }: Pick<En
   return result;
 }
 
-export function getEnergySourceColor(type: string) {
+export function getEnergySourceColor(type: string, direction: 'from' | 'to' = 'from') {
   if (type === 'solar') {
-    return 'var(--warning-color)';
+    return 'var(--energy-solar-color)';
   }
   if (type === 'battery') {
-    return 'var(--success-color)';
+    return direction === 'to' ? 'var(--energy-battery-in-color)' : 'var(--energy-battery-out-color)';
+  }
+  if (type === 'grid') {
+    return direction === 'to' ? 'var(--energy-grid-return-color)' : 'var(--energy-grid-consumption-color)';
   }
   if (type === 'water') {
-    return 'var(--info-color)';
+    return 'var(--energy-water-color)';
   }
   return undefined;
 }

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -348,7 +348,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           type: 'entity',
           name: '',
           subtract_entities: netFlows && importEntity ? [importEntity] : undefined,
-          color: getEnergySourceColor(grid.type),
+          color: getEnergySourceColor(grid.type, 'to'),
         });
         sources.forEach(source => {
           const sId = fromEntity(source);
@@ -365,7 +365,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           type: 'entity',
           name: '',
           subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
-          color: getEnergySourceColor(battery.type),
+          color: getEnergySourceColor(battery.type, 'to'),
         });
         sources.forEach(source => {
           const sId = fromEntity(source);

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -13,14 +13,17 @@ import './print-config';
 import { HassEntities } from 'home-assistant-js-websocket';
 import {
   Conversions,
+  DeviceConsumptionEnergyPreference,
   EnergyCollection,
   EnergyData,
-  ENERGY_SOURCE_TYPES,
+  EnergySource,
   getEnergyDataCollection,
   getEnergySourceColor,
   getStatistics,
   getEnergyPreferences,
   EnergyPreferences,
+  isRateMode,
+  sourceTypesForMode,
 } from './energy';
 import { until } from 'lit/directives/until';
 import { fetchFloorRegistry, FloorRegistryEntry, getEntitiesByArea, HomeAssistantReal } from './hass';
@@ -164,6 +167,13 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       getTimePeriod();
       const interval = setInterval(getTimePeriod, this.config.throttle || 1000);
       return [() => clearInterval(interval)];
+    } else if (isAutoconfig && !this.config.sections.length) {
+      // Rate-mode autoconfig (mode = 'power' | 'water_flow'): no date selection
+      // and no time_period_from. Build the graph once from energy preferences
+      // and let live hass.states drive subsequent renders.
+      this.autoconfig().catch((err: any) => {
+        this.error = new Error(err?.message || err);
+      });
     }
     return [];
   }
@@ -206,21 +216,28 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     if (!prefs) {
       prefs = await getEnergyPreferences(this.hass);
     }
+    const mode = this.config.autoconfig?.mode || 'energy';
+    const rateMode = isRateMode(mode);
+    const validTypes = sourceTypesForMode(mode);
     const netFlows = this.config.autoconfig?.net_flows !== false;
-    const sources: typeof prefs.energy_sources = [];
+
+    const fromEntity = (s: EnergySource): string | undefined =>
+      rateMode ? s.stat_rate : s.stat_energy_from;
+    const toEntity = (s: EnergySource): string | undefined =>
+      mode === 'energy' ? s.stat_energy_to : undefined;
+    const deviceEntity = (d: DeviceConsumptionEnergyPreference): string | undefined =>
+      rateMode ? d.stat_rate : d.stat_consumption;
+    const deviceList: DeviceConsumptionEnergyPreference[] =
+      mode === 'water' || mode === 'water_flow'
+        ? prefs.device_consumption_water || []
+        : prefs.device_consumption || [];
+
+    const sources: EnergySource[] = [];
     (prefs?.energy_sources || []).forEach(s => {
-      if (!ENERGY_SOURCE_TYPES.includes(s.type)) {
-        return;
-      }
-      [s, ...(s.flow_from || [])].forEach(f => {
-        if (f.stat_energy_from) {
-          if (!this.hass.states[f.stat_energy_from]) {
-            console.warn('Ignoring missing entity ' + f.stat_energy_from);
-          } else {
-            sources.push({ ...s, ...f });
-          }
-        }
-      });
+      if (!validTypes.includes(s.type)) return;
+      const id = fromEntity(s);
+      if (!id || !this.hass.states[id]) return;
+      sources.push(s);
     });
     sources.sort((s1, s2) => {
       // sort to solar, battery, grid
@@ -241,11 +258,28 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const links: Config['links'] = [];
     const sections: SectionConfig[] = [];
 
-    prefs.device_consumption.forEach((device, idx) => {
+    // `included_in_stat` always references a parent device's `stat_consumption`.
+    // In rate modes the parent's node id is its `stat_rate`, so we need a
+    // stat_consumption → resolved-node-id map to rewrite child.parent into
+    // something that actually exists in the graph. In energy/water modes the
+    // map is identity. Parents whose entity is missing for the current mode
+    // are absent from the map, and their children fall back to no-parent.
+    const consumptionToNodeId: Record<string, string> = {};
+    deviceList.forEach(device => {
+      const id = deviceEntity(device);
+      if (id) consumptionToNodeId[device.stat_consumption] = id;
+    });
+
+    deviceList.forEach((device, idx) => {
+      const id = deviceEntity(device);
+      if (!id) return;
+      const parent = device.included_in_stat
+        ? consumptionToNodeId[device.included_in_stat]
+        : undefined;
       const node = {
-        id: device.stat_consumption,
+        id,
         name: device.name,
-        parent: device.included_in_stat,
+        parent,
         color: `var(--color-${(idx % 54) + 1})`,
       };
       if (node.parent) {
@@ -263,21 +297,22 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     let currentSection = 0;
 
     sources.forEach(source => {
-      if (!source.stat_energy_from) return;
+      const id = fromEntity(source)!;
+      const exportId = toEntity(source);
       const subtract = (source.type === 'grid' || source.type === 'battery') && !netFlows
         ? undefined
-        : source.stat_energy_to
-          ? [source.stat_energy_to]
-          : source.flow_to?.map(e => e.stat_energy_to).filter(Boolean) as string[] | undefined;
+        : exportId
+          ? [exportId]
+          : undefined;
       nodes.push({
-        id: source.stat_energy_from,
+        id,
         section: currentSection,
         type: 'entity',
         name: '',
         subtract_entities: subtract,
         color: getEnergySourceColor(source.type),
       });
-      links.push({ source: source.stat_energy_from, target: TOTAL_NODE_ID });
+      links.push({ source: id, target: TOTAL_NODE_ID });
     });
     sections.push({});
 
@@ -295,47 +330,48 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     });
     links.push({ source: TOTAL_NODE_ID, target: UNKNOWN_NODE_ID });
 
-    const gridSources = sources.filter(s => s.type === 'grid');
-    const seenFlowTo = new Set<string>();
-    gridSources.forEach(grid => {
-      const exportEntities = grid.flow_to?.map(e => e.stat_energy_to) ??
-        (grid.stat_energy_to ? [grid.stat_energy_to] : []);
-      const importEntities = grid.flow_from?.map(e => e.stat_energy_from) ??
-        (grid.stat_energy_from ? [grid.stat_energy_from] : []);
-      if (exportEntities.length) {
-        exportEntities.forEach(stat_energy_to => {
-          if (!stat_energy_to || seenFlowTo.has(stat_energy_to)) return;
-          seenFlowTo.add(stat_energy_to);
-          nodes.push({
-            id: stat_energy_to,
-            section: currentSection,
-            type: 'entity',
-            name: '',
-            subtract_entities: netFlows ? importEntities : undefined,
-            color: getEnergySourceColor(grid.type),
-          });
-          sources.forEach(source => {
-            if (!source.stat_energy_from) return;
-            links.push({ source: source.stat_energy_from, target: stat_energy_to });
-          });
+    // Grid export and battery charge nodes only exist in energy mode. In rate
+    // and water modes the source is a single signed/unidirectional sensor, so
+    // there is no separate to-side node.
+    if (mode === 'energy') {
+      const gridSources = sources.filter(s => s.type === 'grid');
+      const seenFlowTo = new Set<string>();
+      gridSources.forEach(grid => {
+        const exportEntity = grid.stat_energy_to;
+        const importEntity = grid.stat_energy_from;
+        if (!exportEntity || seenFlowTo.has(exportEntity)) return;
+        seenFlowTo.add(exportEntity);
+        nodes.push({
+          id: exportEntity,
+          section: currentSection,
+          type: 'entity',
+          name: '',
+          subtract_entities: netFlows && importEntity ? [importEntity] : undefined,
+          color: getEnergySourceColor(grid.type),
+        });
+        sources.forEach(source => {
+          const sId = fromEntity(source);
+          if (!sId) return;
+          links.push({ source: sId, target: exportEntity });
+        });
+      });
+
+      const battery = sources.find(s => s.type === 'battery');
+      if (battery && battery.stat_energy_from && battery.stat_energy_to) {
+        nodes.push({
+          id: battery.stat_energy_to,
+          section: currentSection,
+          type: 'entity',
+          name: '',
+          subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
+          color: getEnergySourceColor(battery.type),
+        });
+        sources.forEach(source => {
+          const sId = fromEntity(source);
+          if (!sId) return;
+          links.push({ source: sId, target: battery.stat_energy_to! });
         });
       }
-    });
-
-    const battery = sources.find(s => s.type === 'battery');
-    if (battery && battery.stat_energy_from && battery.stat_energy_to) {
-      nodes.push({
-        id: battery.stat_energy_to,
-        section: currentSection,
-        type: 'entity',
-        name: '',
-        subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
-        color: getEnergySourceColor(battery.type),
-      });
-      sources.forEach(source => {
-        if (!source.stat_energy_from) return;
-        links.push({ source: source.stat_energy_from, target: battery.stat_energy_to! });
-      });
     }
     sections.push({});
 

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -118,7 +118,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         }
       };
       const energyPromise = new Promise<EnergyCollection>(getEnergyDataCollectionPoll);
-      setTimeout(() => {
+      const noDataTimeout = setTimeout(() => {
         if (!this.error && !Object.keys(this.states).length) {
           this.error = new Error('Something went wrong. No energy data received.');
           console.debug(getEnergyDataCollection(this.hass, this.config.energy_collection_key));
@@ -137,6 +137,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
             }
           }
           return collection.subscribe(async data => {
+            clearTimeout(noDataTimeout);
             if (isAutoconfig && !this.config.nodes.length) {
               try {
                 await this.autoconfig(collection.prefs);

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -79,6 +79,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
 
   private async _fetchStats(range: Pick<EnergyData, 'start' | 'end'>): Promise<void> {
     if (!this.entityIds.length) return;
+    if (isRateMode(this.config.autoconfig?.mode || 'energy')) return;
     const conversions: Conversions = {
       convert_units_to: this.config.convert_units_to!,
       co2_intensity_entity: this.config.co2_intensity_entity!,

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -22,6 +22,7 @@
       "time_period_from": "Time period from",
       "time_period_to": "Time period to",
       "autoconfig": "Autoconfig",
+      "autoconfig_mode": "Mode",
       "print_yaml": "Print auto generated config yaml",
       "layout": "Layout",
       "show_names": "Show names",
@@ -78,6 +79,12 @@
       "auto": "Auto",
       "vertical": "Vertical",
       "horizontal": "Horizontal"
+    },
+    "autoconfig_mode": {
+      "energy": "Energy",
+      "power": "Power",
+      "water": "Water",
+      "water_flow": "Water flow"
     }
   }
 }

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -19,6 +19,7 @@
     "section_options": "Opções",
     "fields": {
       "autoconfig": "Auto-configurar",
+      "autoconfig_mode": "Modo",
       "print_yaml": "Imprimir yaml da configuração gerada automaticamente",
       "layout": "Layout",
       "show_names": "Mostrar nomes",
@@ -75,6 +76,12 @@
       "auto": "Automático",
       "vertical": "Vertical",
       "horizontal": "Horizontal"
+    },
+    "autoconfig_mode": {
+      "energy": "Energia",
+      "power": "Potência",
+      "water": "Água",
+      "water_flow": "Vazão de água"
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,12 +25,15 @@ export const DEFAULT_CONFIG: Config = {
   sections: [],
 };
 
+export type AutoconfigMode = 'energy' | 'power' | 'water' | 'water_flow';
+
 export interface SankeyChartConfig extends LovelaceCardConfig {
   type: string;
   nodes?: Node[];
   links?: Link[];
   sections?: SectionConfig[];
   autoconfig?: {
+    mode?: AutoconfigMode;
     print_yaml?: boolean;
     group_by_floor?: boolean;
     group_by_area?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,13 +241,15 @@ export function normalizeConfig(conf: SankeyChartConfig | V3Config, isMetric?: b
     ? migrateV3Config(conf as V3Config)
     : cloneObj(conf);
 
-  const { autoconfig } = conf;
+  const { autoconfig } = config;
   if (autoconfig || typeof autoconfig === 'object') {
+    const mode = (typeof autoconfig === 'object' && autoconfig.mode) || 'energy';
+    const rateMode = mode === 'power' || mode === 'water_flow';
     config = {
-      energy_date_selection: !config.time_period_from,
-      unit_prefix: 'k',
-      round: 1,
       ...config,
+      energy_date_selection: config.energy_date_selection ?? (!config.time_period_from && !rateMode),
+      unit_prefix: config.unit_prefix ?? (mode === 'energy' ? 'k' : ''),
+      round: config.round ?? 1,
       nodes: config.nodes || [],
       links: config.links || [],
     };


### PR DESCRIPTION
fixes #205

## Summary

Sparked from #348 by @kvanzuijlen

- Adds `autoconfig.mode` (`energy` | `power` | `water` | `water_flow`) so a single card can drive all four Sankey shapes HA ships natively.
- Default is `energy`; existing autoconfig configs keep their current behavior.
- Power and water_flow are real-time (read from live `hass.states`); water aggregates like energy.
- Replaces the inline editor toggle with an `<ha-select>` for the mode, alongside the existing print_yaml switch.
- Uses HA's energy CSS color vars for autoconfig sources

## Per-mode resolution (mirrors HA's data model)

| Mode | Source from | Source to (grid/battery) | Devices array | Device entity |
|---|---|---|---|---|
| `energy` | `source.stat_energy_from` | `source.stat_energy_to` | `device_consumption` | `stat_consumption` |
| `power` | `source.stat_rate` | — (signed) | `device_consumption` | `stat_rate` |
| `water` | `source.stat_energy_from` | — | `device_consumption_water` | `stat_consumption` |
| `water_flow` | `source.stat_rate` | — | `device_consumption_water` | `stat_rate` |

`flow_from` / `flow_to` / `power_config` / `stat_rate_inverted` are not read in any mode.

`included_in_stat` references the parent device's `stat_consumption`, so in rate modes we resolve it through a `stat_consumption → resolved node id` map. Children whose parent is missing for the selected mode fall back to no-parent instead of dangling.

`normalizeConfig` sets `unit_prefix=''` and `energy_date_selection=false` for rate modes (energy keeps `unit_prefix='k'` / `energy_date_selection=true`).

BEGIN_COMMIT_OVERRIDE
feat: add autoconfig mode option (energy/power/water/water_flow) - requires 2025.12 or later depending on the mode

feat!: Align autoconfig colors with HA's energy colors
END_COMMIT_OVERRIDE
