### PR TITLE
fix(#352): honor link value on cross-section connections

### DIFF
--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -132,3 +132,135 @@ describe('Missing entities', () => {
     expect(() => element.requestUpdate()).not.toThrow();
   });
 });
+
+describe('Link value (connection entity)', () => {
+  const valueHass = mockHass({
+    'sensor.parent': {
+      entity_id: 'sensor.parent',
+      state: '100',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.child': {
+      entity_id: 'sensor.child',
+      state: '100',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.cap': {
+      entity_id: 'sensor.cap',
+      state: '30',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.parent_a': {
+      entity_id: 'sensor.parent_a',
+      state: '100',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.parent_b': {
+      entity_id: 'sensor.parent_b',
+      state: '100',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.target': {
+      entity_id: 'sensor.target',
+      state: '200',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.cap_a': {
+      entity_id: 'sensor.cap_a',
+      state: '10',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.cap_b': {
+      entity_id: 'sensor.cap_b',
+      state: '20',
+      attributes: { unit_of_measurement: 'W' },
+    },
+  });
+
+  async function renderChart(config: SankeyChartConfig) {
+    const element = window.document.createElement(ROOT_TAG) as SankeyChart;
+    // @ts-ignore
+    element.hass = valueHass as HomeAssistant;
+    element.setConfig(config, true);
+    document.body.appendChild(element);
+    await element.updateComplete;
+    const base = element.shadowRoot?.querySelector('sankey-chart-base') as LitElement;
+    await base.updateComplete;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { element, base, connections: (base as any).connections as Array<any> };
+  }
+
+  it('caps a cross-section link by its value sensor', async () => {
+    const config: SankeyChartConfig = {
+      type: 'custom:sankey-chart',
+      nodes: [
+        { id: 'sensor.parent', section: 0, type: 'entity', name: '' },
+        { id: 'sensor.child', section: 2, type: 'entity', name: '' },
+      ],
+      links: [
+        { source: 'sensor.parent', target: 'sensor.child', value: 'sensor.cap' },
+      ],
+      sections: [{}, {}, {}],
+    };
+    const { connections, element } = await renderChart(config);
+    const conn = connections.find(
+      c => c.parent.id === 'sensor.parent' && c.child.id === 'sensor.child',
+    );
+    expect(conn).toBeDefined();
+    expect(conn.connection_entity_id).toBe('sensor.cap');
+    expect(conn.state).toBe(30);
+    element.remove();
+  });
+
+  it('caps an adjacent-section link by its value sensor (regression guard)', async () => {
+    const config: SankeyChartConfig = {
+      type: 'custom:sankey-chart',
+      nodes: [
+        { id: 'sensor.parent', section: 0, type: 'entity', name: '' },
+        { id: 'sensor.child', section: 1, type: 'entity', name: '' },
+      ],
+      links: [
+        { source: 'sensor.parent', target: 'sensor.child', value: 'sensor.cap' },
+      ],
+      sections: [{}, {}],
+    };
+    const { connections, element } = await renderChart(config);
+    const conn = connections.find(
+      c => c.parent.id === 'sensor.parent' && c.child.id === 'sensor.child',
+    );
+    expect(conn).toBeDefined();
+    expect(conn.connection_entity_id).toBe('sensor.cap');
+    expect(conn.state).toBe(30);
+    element.remove();
+  });
+
+  it('caps two parallel cross-gap flows independently when sharing a passthrough chain', async () => {
+    const config: SankeyChartConfig = {
+      type: 'custom:sankey-chart',
+      nodes: [
+        { id: 'sensor.parent_a', section: 0, type: 'entity', name: '' },
+        { id: 'sensor.parent_b', section: 0, type: 'entity', name: '' },
+        { id: 'sensor.target', section: 2, type: 'entity', name: '' },
+      ],
+      links: [
+        { source: 'sensor.parent_a', target: 'sensor.target', value: 'sensor.cap_a' },
+        { source: 'sensor.parent_b', target: 'sensor.target', value: 'sensor.cap_b' },
+      ],
+      sections: [{}, {}, {}],
+    };
+    const { connections, element } = await renderChart(config);
+    const connA = connections.find(
+      c => c.parent.id === 'sensor.parent_a' && c.child.id === 'sensor.target',
+    );
+    const connB = connections.find(
+      c => c.parent.id === 'sensor.parent_b' && c.child.id === 'sensor.target',
+    );
+    expect(connA).toBeDefined();
+    expect(connB).toBeDefined();
+    expect(connA.connection_entity_id).toBe('sensor.cap_a');
+    expect(connB.connection_entity_id).toBe('sensor.cap_b');
+    expect(connA.state).toBe(10);
+    expect(connB.state).toBe(20);
+    element.remove();
+  });
+});

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -128,6 +128,7 @@ export class Chart extends LitElement {
               prevChildState: 0,
               ready: false,
               passthroughs,
+              connection_entity_id: typeof childConf === 'object' ? childConf.connection_entity_id : undefined,
             };
             this.connections.push(connection);
             if (!this.connectionsByParent.has(ent)) {
@@ -204,9 +205,8 @@ export class Chart extends LitElement {
     if (!parentState || !childState) {
       connection.state = 0;
     } else {
-      const connConfig = parent.children.find(c => getEntityId(c) === child.id);
-      if (typeof connConfig === 'object' && connConfig.connection_entity_id) {
-        const connectionState = this._getMemoizedState(connConfig.connection_entity_id).state ?? 0;
+      if (connection.connection_entity_id) {
+        const connectionState = this._getMemoizedState(connection.connection_entity_id).state ?? 0;
         connection.state = Math.min(parentState, childState, connectionState);
       } else {
         connection.state = Math.min(parentState, childState);

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,7 @@ export interface ConnectionState {
   calculating?: boolean;
   highlighted?: boolean;
   passthroughs: NodeInternal[];
+  connection_entity_id?: string;
 }
 
 export interface NormalizedState {


### PR DESCRIPTION
## Summary

Fixes #352. When a link's source and target sections were not adjacent (gap ≥ 2), the link's `value` field — the "connection entity" sensor that caps the flow — was silently ignored.

## Root cause

Cross-gap links are auto-routed through synthetic passthroughs in `autoRouteCrossGapLinks`, which sets `link.target = <passthrough_id>`. After `convertNodesToSections` translates `link.value` into a `ChildConfig` on the parent, that `ChildConfig`'s `entity_id` references the passthrough, not the actual target. When `willUpdate` later collapses the passthrough chain into a single `ConnectionState` (parent → real target), `_calcConnection`'s lookup `parent.children.find(c => getEntityId(c) === child.id)` couldn't find the entry, and `connection_entity_id` was never read.

## Fix

Carry `connection_entity_id` on the `ConnectionState` itself, captured from the immediate `childConf` while the connection is being built in `willUpdate`. The same code path now serves both adjacent-section and cross-gap links uniformly — no more id-based lookup against `parent.children`.

## Test plan

- [x] Added three regression tests in `__tests__/basic.test.ts`:
  - Cross-gap link with `value` is capped by the sensor (the bug).
  - Adjacent-section link with `value` (regression guard).
  - Two parallel cross-gap flows sharing a passthrough chain are capped independently.
- [x] `npm test` — all 79 tests pass, no snapshot changes.
- [x] `npm run lint` — no new warnings.
- [x] `npm run build` — clean.