### PR TITLE
fix(#356): strip derived section entities from print_yaml output

### DIFF
--- a/src/print-config.ts
+++ b/src/print-config.ts
@@ -19,8 +19,21 @@ export class PrintConfig extends LitElement {
   }
 
   firstUpdated() {
+    // The internal `Config.sections[*].entities` is derived from `nodes`/`links`
+    // via convertNodesToSections. If it ends up in the pasted-back YAML,
+    // normalizeConfig's v3 detection (sections[*].entities truthy) triggers
+    // migrateV3Config, which discards the v4 nodes/links and rebuilds them
+    // from undefined entity_ids — see #356.
+    const { sections, autoconfig, ...rest } = this.config;
+    const printable: Record<string, unknown> = {
+      ...rest,
+      sections: sections.map(({ entities: _entities, ...sectionConfig }) => sectionConfig),
+    };
+    if (autoconfig) {
+      printable.autoconfig = { ...autoconfig, print_yaml: false };
+    }
     // @ts-ignore
-    this.yamlEditor.setValue(this.config);
+    this.yamlEditor.setValue(printable);
   }
 
   protected render(): TemplateResult | void {


### PR DESCRIPTION
Fixes #356.

## Summary

When `autoconfig.print_yaml: true` was set, copying the printed YAML into a new card threw `Missing child entity total`.

`print-config.ts` was dumping the fully-normalized internal `Config` straight into `ha-yaml-editor`. That object describes the same flow twice — once as v4 `nodes`/`links`, once as `sections[*].entities[*].children` (derived from links by `convertNodesToSections`, but using v4 field names: `id`, not `entity_id`).

On paste-back, `normalizeConfig` saw `sections[].entities` and routed through `migrateV3Config`, which reads `entity_id` (undefined on v4-shaped entries), discarded the real `nodes`/`links`, and rebuilt every node with `id: undefined`. The chart then failed to resolve children and threw at `chart.ts:113`.

## Changes

- `src/print-config.ts`: build a printable config that strips the derived `entities` from each section (preserving `sort_by`, `sort_dir`, `sort_group_by_parent`, `min_width`) and sets `autoconfig.print_yaml: false` so the editor doesn't reappear when the printed YAML is pasted back.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new warnings
- [x] `npm test` — 79/79 pass
- [ ] Manual round-trip in a HA dashboard: copy the printed YAML into a new card with `autoconfig: { mode: power, print_yaml: true }`; chart renders, no `Missing child entity` error, print editor does not reappear.