### PR TITLE
fix(#357): show grid export and battery charge in power-mode autoconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Install through [HACS](https://hacs.xyz/)
 
 | Name              | Type    | Requirement  | Default             | Description                                 |
 | ----------------- | ------- | ------------ | ------------------- | ------------------------------------------- |
-| id                | string  | **Required** |                     | Entity id of the sensor
+| id                | string  | **Required** |                     | Unique node id in the chart graph. Defaults to the entity to read, unless `entity_id` is set.
+| entity_id         | string  | **Optional** | value of `id`       | Entity id to read state from. Lets a synthetic `id` (e.g. `sensor.foo__copy`) reference a real entity, so two nodes can render the same entity from different angles. See [filters](#filters).
 | section           | number  | **Optional** |                     | Index of the section this node belongs to (0-based). Determines horizontal/vertical position
 | attribute         | string  | **Optional** |                     | Use the value of an attribute instead of the state of the entity. unit_of_measurement and id will still come from the entity. For more complex customization, please use HA templates.
 | type              | string  | **Optional** | entity              | Possible values are 'entity', 'passthrough', 'remaining_parent_state', 'remaining_child_state'. See [entity types](#entity-types)
@@ -68,6 +69,7 @@ Install through [HACS](https://hacs.xyz/)
 | color             | string/object | **Optional** | var(--primary-color)| Color of the box. Can be a simple color string ('red', '#FFAA2C', 'rgb(255, 170, 44)', 'random') or a range object for state-based coloring. See [color ranges](#color-ranges)
 | add_entities      | list    | **Optional** |                     | Experimental. List of entity ids. Their states will be added to this entity, showing a sum.
 | subtract_entities | list    | **Optional** |                     | Experimental. List of entity ids. Their states will be subtracted from this entity's state
+| filters           | list    | **Optional** |                     | List of value transforms applied before the positive clamp. See [filters](#filters).
 | tap_action        | action  | **Optional** | more-info           | Home assistant action to perform on tap. Supported action types are `more-info`, `zoom`, `navigate`, `url`, `toggle`, `call-service`, `fire-dom-event`. Ex: `action: zoom`
 | double_tap_action | action  | **Optional** |                     | Home assistant action to perform on double tap
 | hold_action       | action  | **Optional** |                     | Home assistant action to perform on hold
@@ -81,6 +83,29 @@ Install through [HACS](https://hacs.xyz/)
 | source               | string  | **Required** |                     | Entity id of the parent/source node
 | target               | string  | **Required** |                     | Entity id of the child/target node
 | value                | string  | **Optional** |                     | Entity id of a sensor that determines how much of the parent flows into the child (connection entity)
+
+### Filters
+
+Filters transform a node's raw state before the chart's automatic clamp to ≥ 0. Each filter is an object with a `type` discriminator.
+
+| type     | Effect                                                                                                                              |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `negate` | Negates the raw value. Combined with the positive clamp, isolates the negative half of a signed sensor as a positive flow.          |
+
+Pair `filters` with `entity_id` to render the negative half of a signed sensor as its own node — the sibling node reads the same entity but flips the sign, so positive readings collapse to 0 and negative readings flow as their absolute value. This is how power-mode [autoconfig](#autoconfig) surfaces grid export and battery charging from a single signed `stat_rate`.
+
+```yaml
+nodes:
+  # Import flow: positive part of the signed sensor (negative readings clamp to 0).
+  - id: sensor.grid_power
+    section: 0
+  # Export flow: negate first, then clamp — surfaces only the negative readings.
+  - id: sensor.grid_power__export
+    entity_id: sensor.grid_power
+    filters:
+      - type: negate
+    section: 2
+```
 
 ### Color ranges
 

--- a/README.md
+++ b/README.md
@@ -86,24 +86,28 @@ Install through [HACS](https://hacs.xyz/)
 
 ### Filters
 
-Filters transform a node's raw state before the chart's automatic clamp to ≥ 0. Each filter is an object with a `type` discriminator.
+Filters transform a node's raw state before the chart's automatic clamp to ≥ 0. Each entry is a single-key object naming the transform (ESPHome/Plotly style).
 
-| type     | Effect                                                                                                                              |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `negate` | Negates the raw value. Combined with the positive clamp, isolates the negative half of a signed sensor as a positive flow.          |
+| Filter     | Argument | Effect                                                                  |
+| ---------- | -------- | ----------------------------------------------------------------------- |
+| `multiply` | number   | Multiplies the raw value. Use `-1` to flip the sign of a signed sensor. |
+| `divide`   | number   | Divides the raw value.                                                  |
+| `offset`   | number   | Adds the argument to the raw value (use a negative number to subtract). |
 
-Pair `filters` with `entity_id` to render the negative half of a signed sensor as its own node — the sibling node reads the same entity but flips the sign, so positive readings collapse to 0 and negative readings flow as their absolute value. This is how power-mode [autoconfig](#autoconfig) surfaces grid export and battery charging from a single signed `stat_rate`.
+Filters apply in order, so `[{ multiply: 0.001 }, { offset: -5 }]` first scales then offsets.
+
+Pair `filters` with `entity_id` to render the negative half of a signed sensor as its own node — the sibling node reads the same entity but applies `multiply: -1`, so positive readings collapse to 0 (via the chart's positive clamp) and negative readings flow as their absolute value. This is how power-mode [autoconfig](#autoconfig) surfaces grid export and battery charging from a single signed `stat_rate`.
 
 ```yaml
 nodes:
   # Import flow: positive part of the signed sensor (negative readings clamp to 0).
   - id: sensor.grid_power
     section: 0
-  # Export flow: negate first, then clamp — surfaces only the negative readings.
+  # Export flow: flip sign first, then clamp — surfaces only the negative readings.
   - id: sensor.grid_power__export
     entity_id: sensor.grid_power
     filters:
-      - type: negate
+      - multiply: -1
     section: 2
 ```
 

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -69,6 +69,31 @@ describe('SankeyChart autoconfig', () => {
     });
   });
 
+  it('energy mode: two batteries with distinct stat_energy_to produce two charge nodes', async () => {
+    hass.states['sensor.battery_a_in'] = { entity_id: 'sensor.battery_a_in', state: '5' } as any;
+    hass.states['sensor.battery_a_out'] = { entity_id: 'sensor.battery_a_out', state: '3' } as any;
+    hass.states['sensor.battery_b_in'] = { entity_id: 'sensor.battery_b_in', state: '4' } as any;
+    hass.states['sensor.battery_b_out'] = { entity_id: 'sensor.battery_b_out', state: '2' } as any;
+    (getEnergyPreferences as jest.Mock).mockResolvedValue({
+      energy_sources: [
+        { type: 'battery', stat_energy_from: 'sensor.battery_a_in', stat_energy_to: 'sensor.battery_a_out' },
+        { type: 'battery', stat_energy_from: 'sensor.battery_b_in', stat_energy_to: 'sensor.battery_b_out' },
+      ],
+      device_consumption: [],
+    });
+    (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sankeyChart as any)['autoconfig']();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (sankeyChart as any).config;
+    const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+    // Pre-fix only the first battery got a charge node — see #357.
+    expect(allNodeIds).toContain('sensor.battery_a_out');
+    expect(allNodeIds).toContain('sensor.battery_b_out');
+  });
+
   it('removes subtract_entities with net_flows: false', async () => {
     hass.states['sensor.grid_out'] = { entity_id: 'sensor.grid_out', state: '3' } as any;
     sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { net_flows: false } }, true);
@@ -639,8 +664,81 @@ describe('SankeyChart autoconfig', () => {
       expect(allNodeIds).not.toContain('sensor.grid_in');
       expect(allNodeIds).not.toContain('sensor.solar');
       expect(allNodeIds).not.toContain('sensor.device1');
-      // No separate to-side export node in rate mode (signed stat_rate covers both directions).
-      expect(allNodeIds).not.toContain('sensor.grid_out');
+      // Grid stat_rate is signed; surface the export half via a synthetic
+      // sibling node with filters:[{type:'negate'}]. See #357.
+      const gridExport = config.nodes.find(
+        (n: { id: string }) => n.id === 'sensor.grid_power_in__to_auto',
+      );
+      expect(gridExport).toBeDefined();
+      expect(gridExport.entity_id).toBe('sensor.grid_power_in');
+      expect(gridExport.filters).toEqual([{ type: 'negate' }]);
+      // Solar is unidirectional — no export node for solar.
+      expect(allNodeIds).not.toContain('sensor.solar_power__to_auto');
+      // Every source links to the export node (mirroring energy-mode pattern).
+      const linkFromGrid = config.links.find(
+        (l: { source: string; target: string }) =>
+          l.source === 'sensor.grid_power_in' && l.target === 'sensor.grid_power_in__to_auto',
+      );
+      expect(linkFromGrid).toBeDefined();
+      const linkFromSolar = config.links.find(
+        (l: { source: string; target: string }) =>
+          l.source === 'sensor.solar_power' && l.target === 'sensor.grid_power_in__to_auto',
+      );
+      expect(linkFromSolar).toBeDefined();
+    });
+
+    it('mode=power: creates battery charge node from signed stat_rate', async () => {
+      hass.states['sensor.battery_power'] = { entity_id: 'sensor.battery_power', state: '-300' } as any;
+      hass.states['sensor.grid_power_in'] = { entity_id: 'sensor.grid_power_in', state: '1000' } as any;
+      setConfigMode('power');
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_rate: 'sensor.grid_power_in' },
+          { type: 'battery', stat_energy_from: 'sensor.battery_in', stat_energy_to: 'sensor.battery_out', stat_rate: 'sensor.battery_power' },
+        ],
+        device_consumption: [],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      const config = (sankeyChart as any).config;
+
+      const charge = config.nodes.find(
+        (n: { id: string }) => n.id === 'sensor.battery_power__to_auto',
+      );
+      expect(charge).toBeDefined();
+      expect(charge.entity_id).toBe('sensor.battery_power');
+      expect(charge.filters).toEqual([{ type: 'negate' }]);
+      // Battery and grid both get their own to-side nodes (dedup by stat_rate).
+      const gridExport = config.nodes.find(
+        (n: { id: string }) => n.id === 'sensor.grid_power_in__to_auto',
+      );
+      expect(gridExport).toBeDefined();
+    });
+
+    it('mode=power: two batteries with distinct stat_rates produce two charge nodes', async () => {
+      hass.states['sensor.battery_a_power'] = { entity_id: 'sensor.battery_a_power', state: '100' } as any;
+      hass.states['sensor.battery_b_power'] = { entity_id: 'sensor.battery_b_power', state: '-50' } as any;
+      setConfigMode('power');
+
+      (getEnergyPreferences as jest.Mock).mockResolvedValue({
+        energy_sources: [
+          { type: 'battery', stat_energy_from: 'sensor.battery_a_in', stat_energy_to: 'sensor.battery_a_out', stat_rate: 'sensor.battery_a_power' },
+          { type: 'battery', stat_energy_from: 'sensor.battery_b_in', stat_energy_to: 'sensor.battery_b_out', stat_rate: 'sensor.battery_b_power' },
+        ],
+        device_consumption: [],
+      });
+      (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+      (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+      await (sankeyChart as any)['autoconfig']();
+      const config = (sankeyChart as any).config;
+
+      const allNodeIds = config.nodes.map((n: { id: string }) => n.id);
+      expect(allNodeIds).toContain('sensor.battery_a_power__to_auto');
+      expect(allNodeIds).toContain('sensor.battery_b_power__to_auto');
     });
 
     it('mode=power: remaps included_in_stat (parent stat_consumption) to parent stat_rate', async () => {

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -665,13 +665,13 @@ describe('SankeyChart autoconfig', () => {
       expect(allNodeIds).not.toContain('sensor.solar');
       expect(allNodeIds).not.toContain('sensor.device1');
       // Grid stat_rate is signed; surface the export half via a synthetic
-      // sibling node with filters:[{type:'negate'}]. See #357.
+      // sibling node with filters:[{multiply:-1}]. See #357.
       const gridExport = config.nodes.find(
         (n: { id: string }) => n.id === 'sensor.grid_power_in__to_auto',
       );
       expect(gridExport).toBeDefined();
       expect(gridExport.entity_id).toBe('sensor.grid_power_in');
-      expect(gridExport.filters).toEqual([{ type: 'negate' }]);
+      expect(gridExport.filters).toEqual([{ multiply: -1 }]);
       // Solar is unidirectional — no export node for solar.
       expect(allNodeIds).not.toContain('sensor.solar_power__to_auto');
       // Every source links to the export node (mirroring energy-mode pattern).
@@ -710,7 +710,7 @@ describe('SankeyChart autoconfig', () => {
       );
       expect(charge).toBeDefined();
       expect(charge.entity_id).toBe('sensor.battery_power');
-      expect(charge.filters).toEqual([{ type: 'negate' }]);
+      expect(charge.filters).toEqual([{ multiply: -1 }]);
       // Battery and grid both get their own to-side nodes (dedup by stat_rate).
       const gridExport = config.nodes.find(
         (n: { id: string }) => n.id === 'sensor.grid_power_in__to_auto',

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -267,8 +267,8 @@ describe('Link value (connection entity)', () => {
 
 describe('Node filters + entity_id (sign-split signed sensors)', () => {
   // Power-mode autoconfig surfaces grid export / battery charge by attaching
-  // a sibling node that reads the same signed stat_rate but negates it
-  // before the positive clamp. See #357.
+  // a sibling node that reads the same signed stat_rate but flips its sign
+  // (multiply:-1) before the positive clamp. See #357.
   const signedHass = mockHass({
     'sensor.signed_pos': {
       entity_id: 'sensor.signed_pos',
@@ -299,16 +299,16 @@ describe('Node filters + entity_id (sign-split signed sensors)', () => {
     return { element, base };
   }
 
-  it('reads via entity_id and applies negate filter (negative → positive)', async () => {
+  it('reads via entity_id and applies multiply:-1 filter (negative → positive)', async () => {
     const config: SankeyChartConfig = {
       type: 'custom:sankey-chart',
       nodes: [
         // Synthetic node id; entity_id points at a signed sensor reading -500.
-        // After negate the raw value becomes +500, then the positive clamp keeps it.
+        // After multiply:-1 the raw value becomes +500, then the positive clamp keeps it.
         {
           id: 'sensor.signed_neg__to_auto',
           entity_id: 'sensor.signed_neg',
-          filters: [{ type: 'negate' }],
+          filters: [{ multiply: -1 }],
           section: 0,
           type: 'entity',
           name: '',

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -264,3 +264,68 @@ describe('Link value (connection entity)', () => {
     element.remove();
   });
 });
+
+describe('Node filters + entity_id (sign-split signed sensors)', () => {
+  // Power-mode autoconfig surfaces grid export / battery charge by attaching
+  // a sibling node that reads the same signed stat_rate but negates it
+  // before the positive clamp. See #357.
+  const signedHass = mockHass({
+    'sensor.signed_pos': {
+      entity_id: 'sensor.signed_pos',
+      state: '1000',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.signed_neg': {
+      entity_id: 'sensor.signed_neg',
+      state: '-500',
+      attributes: { unit_of_measurement: 'W' },
+    },
+    'sensor.sink': {
+      entity_id: 'sensor.sink',
+      state: '0',
+      attributes: { unit_of_measurement: 'W' },
+    },
+  });
+
+  async function renderSignedChart(config: SankeyChartConfig) {
+    const element = window.document.createElement(ROOT_TAG) as SankeyChart;
+    // @ts-ignore
+    element.hass = signedHass as HomeAssistant;
+    element.setConfig(config, true);
+    document.body.appendChild(element);
+    await element.updateComplete;
+    const base = element.shadowRoot?.querySelector('sankey-chart-base') as LitElement;
+    await base.updateComplete;
+    return { element, base };
+  }
+
+  it('reads via entity_id and applies negate filter (negative → positive)', async () => {
+    const config: SankeyChartConfig = {
+      type: 'custom:sankey-chart',
+      nodes: [
+        // Synthetic node id; entity_id points at a signed sensor reading -500.
+        // After negate the raw value becomes +500, then the positive clamp keeps it.
+        {
+          id: 'sensor.signed_neg__to_auto',
+          entity_id: 'sensor.signed_neg',
+          filters: [{ type: 'negate' }],
+          section: 0,
+          type: 'entity',
+          name: '',
+        },
+        { id: 'sensor.sink', section: 1, type: 'entity', name: '' },
+      ],
+      links: [{ source: 'sensor.signed_neg__to_auto', target: 'sensor.sink' }],
+      sections: [{}, {}],
+    };
+    const { base, element } = await renderSignedChart(config);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sections = (base as any).sections as Array<any>;
+    const sourceBox = sections[0].boxes.find(
+      (b: { id: string }) => b.id === 'sensor.signed_neg__to_auto',
+    );
+    expect(sourceBox).toBeDefined();
+    expect(sourceBox.state).toBe(500);
+    element.remove();
+  });
+});

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -99,7 +99,7 @@ export class Chart extends LitElement {
       this.config.sections.forEach(({ entities }) => {
         entities.forEach(ent => {
           if (ent.type === 'entity') {
-            this.entityIds.push(ent.id);
+            this.entityIds.push(ent.entity_id || ent.id);
           } else if (ent.type === 'passthrough') {
             return;
           }
@@ -239,7 +239,14 @@ export class Chart extends LitElement {
       const unit_of_measurement = this._getUnitOfMeasurement(
         entityConf.unit_of_measurement || entity.attributes.unit_of_measurement,
       );
-      const normalized = {...normalizeStateValue(this.config.unit_prefix, Number(entity.state), unit_of_measurement), last_updated: entity.last_updated};
+      // Filters run before normalizeStateValue clamps negatives to 0, so a
+      // signed sensor splits cleanly: the plain node sees max(state, 0);
+      // a sibling with filters: [{ type: 'negate' }] sees max(-state, 0). See #357.
+      let rawState = Number(entity.state);
+      entityConf.filters?.forEach(f => {
+        if (f.type === 'negate') rawState = -rawState;
+      });
+      const normalized = {...normalizeStateValue(this.config.unit_prefix, rawState, unit_of_measurement), last_updated: entity.last_updated};
 
       if (entityConf.type === 'passthrough') {
         normalized.state = this.connections
@@ -593,7 +600,10 @@ export class Chart extends LitElement {
       return this._getEntityState(realConnection.child);
     }
 
-    let entity = this.states[getEntityId(entityConf)];
+    // `entity_id` lets a synthetic node id (e.g. `${stat_rate}__to_auto`) read
+    // from a real entity without conflicting with the node id used as a graph key.
+    const lookupId = entityConf.entity_id || getEntityId(entityConf);
+    let entity = this.states[lookupId];
     if (!entity) {
       if (this.config.ignore_missing_entities) {
         // Return a fake entity with state 0 if ignoring missing entities
@@ -601,11 +611,11 @@ export class Chart extends LitElement {
           state: 0,
           attributes: {
             unit_of_measurement: entityConf.unit_of_measurement || '',
-            friendly_name: entityConf.name || getEntityId(entityConf),
+            friendly_name: entityConf.name || lookupId,
           },
         };
       }
-      throw new Error('Entity not found "' + getEntityId(entityConf) + '"');
+      throw new Error('Entity not found "' + lookupId + '"');
     }
 
     if (entityConf.attribute) {

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -241,10 +241,12 @@ export class Chart extends LitElement {
       );
       // Filters run before normalizeStateValue clamps negatives to 0, so a
       // signed sensor splits cleanly: the plain node sees max(state, 0);
-      // a sibling with filters: [{ type: 'negate' }] sees max(-state, 0). See #357.
+      // a sibling with filters: [{ multiply: -1 }] sees max(-state, 0). See #357.
       let rawState = Number(entity.state);
       entityConf.filters?.forEach(f => {
-        if (f.type === 'negate') rawState = -rawState;
+        if ('multiply' in f) rawState *= f.multiply;
+        else if ('divide' in f) rawState /= f.divide;
+        else if ('offset' in f) rawState += f.offset;
       });
       const normalized = {...normalizeStateValue(this.config.unit_prefix, rawState, unit_of_measurement), last_updated: entity.last_updated};
 

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -55,6 +55,9 @@ const TOTAL_NODE_ID = 'total';
 const UNKNOWN_NODE_ID = 'unknown';
 const NO_FLOOR = 'no_floor';
 const NO_AREA = 'no_area';
+// Suffix for synthetic export/charge nodes in rate-mode autoconfig (mirrors
+// the existing `__passthrough_N__auto` convention from autoRouteCrossGapLinks).
+const AUTO_TO_SUFFIX = '__to_auto';
 
 type DeviceNode = { id: string; name?: string; parent?: string; color?: string };
 
@@ -332,16 +335,18 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     });
     links.push({ source: TOTAL_NODE_ID, target: UNKNOWN_NODE_ID });
 
-    // Grid export and battery charge nodes only exist in energy mode. In rate
-    // and water modes the source is a single signed/unidirectional sensor, so
-    // there is no separate to-side node.
+    // Grid export and battery charge nodes. In energy mode each direction has
+    // its own counter (stat_energy_from/to). In rate modes there's a single
+    // signed stat_rate per source — a sibling node with filters:[{type:'negate'}]
+    // surfaces the negative half (export/charge) as a positive flow.
     if (mode === 'energy') {
-      const gridSources = sources.filter(s => s.type === 'grid');
       const seenFlowTo = new Set<string>();
-      gridSources.forEach(grid => {
-        const exportEntity = grid.stat_energy_to;
-        const importEntity = grid.stat_energy_from;
-        if (!exportEntity || seenFlowTo.has(exportEntity)) return;
+      const addToNode = (
+        source: EnergySource,
+        exportEntity: string,
+        importEntity: string | undefined,
+      ) => {
+        if (seenFlowTo.has(exportEntity)) return;
         seenFlowTo.add(exportEntity);
         nodes.push({
           id: exportEntity,
@@ -349,31 +354,54 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           type: 'entity',
           name: '',
           subtract_entities: netFlows && importEntity ? [importEntity] : undefined,
-          color: getEnergySourceColor(grid.type, 'to'),
+          color: getEnergySourceColor(source.type, 'to'),
         });
-        sources.forEach(source => {
-          const sId = fromEntity(source);
+        sources.forEach(s => {
+          const sId = fromEntity(s);
           if (!sId) return;
           links.push({ source: sId, target: exportEntity });
         });
-      });
+      };
 
-      const battery = sources.find(s => s.type === 'battery');
-      if (battery && battery.stat_energy_from && battery.stat_energy_to) {
+      sources
+        .filter(s => s.type === 'grid')
+        .forEach(grid => {
+          if (!grid.stat_energy_to) return;
+          addToNode(grid, grid.stat_energy_to, grid.stat_energy_from);
+        });
+
+      sources
+        .filter(s => s.type === 'battery')
+        .forEach(battery => {
+          if (!battery.stat_energy_to || !battery.stat_energy_from) return;
+          addToNode(battery, battery.stat_energy_to, battery.stat_energy_from);
+        });
+    } else if (rateMode) {
+      // Signed stat_rate: positive part already flows from the source node;
+      // a synthetic sibling with negate surfaces the negative part. Dedup by
+      // stat_rate mirrors the energy-mode dedup-by-stat_energy_to.
+      const seenFlowTo = new Set<string>();
+      sources.forEach(source => {
+        if (source.type !== 'grid' && source.type !== 'battery') return;
+        const rateEntity = source.stat_rate;
+        if (!rateEntity || seenFlowTo.has(rateEntity)) return;
+        seenFlowTo.add(rateEntity);
+        const toId = `${rateEntity}${AUTO_TO_SUFFIX}`;
         nodes.push({
-          id: battery.stat_energy_to,
+          id: toId,
+          entity_id: rateEntity,
+          filters: [{ type: 'negate' }],
           section: currentSection,
           type: 'entity',
           name: '',
-          subtract_entities: netFlows ? [battery.stat_energy_from] : undefined,
-          color: getEnergySourceColor(battery.type, 'to'),
+          color: getEnergySourceColor(source.type, 'to'),
         });
-        sources.forEach(source => {
-          const sId = fromEntity(source);
+        sources.forEach(s => {
+          const sId = fromEntity(s);
           if (!sId) return;
-          links.push({ source: sId, target: battery.stat_energy_to! });
+          links.push({ source: sId, target: toId });
         });
-      }
+      });
     }
     sections.push({});
 

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -202,7 +202,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     this.entityIds = [];
     this.config.nodes.forEach(node => {
       if (node.type === 'entity') {
-        this.entityIds.push(node.id);
+        this.entityIds.push(node.entity_id || node.id);
         node.add_entities?.forEach(id => this.entityIds.push(id));
         node.subtract_entities?.forEach(id => this.entityIds.push(id));
       }

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -337,7 +337,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
 
     // Grid export and battery charge nodes. In energy mode each direction has
     // its own counter (stat_energy_from/to). In rate modes there's a single
-    // signed stat_rate per source — a sibling node with filters:[{type:'negate'}]
+    // signed stat_rate per source — a sibling node with filters:[{multiply:-1}]
     // surfaces the negative half (export/charge) as a positive flow.
     if (mode === 'energy') {
       const seenFlowTo = new Set<string>();
@@ -378,8 +378,8 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         });
     } else if (rateMode) {
       // Signed stat_rate: positive part already flows from the source node;
-      // a synthetic sibling with negate surfaces the negative part. Dedup by
-      // stat_rate mirrors the energy-mode dedup-by-stat_energy_to.
+      // a synthetic sibling with multiply:-1 surfaces the negative part. Dedup
+      // by stat_rate mirrors the energy-mode dedup-by-stat_energy_to.
       const seenFlowTo = new Set<string>();
       sources.forEach(source => {
         if (source.type !== 'grid' && source.type !== 'battery') return;
@@ -390,7 +390,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         nodes.push({
           id: toId,
           entity_id: rateEntity,
-          filters: [{ type: 'negate' }],
+          filters: [{ multiply: -1 }],
           section: currentSection,
           type: 'entity',
           name: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,9 +107,12 @@ export interface Link {
 
 export type NodeType = 'entity' | 'passthrough' | 'remaining_parent_state' | 'remaining_child_state';
 
-// Discriminated union to keep future transforms (clamp, scale, abs, …) additive.
+// ESPHome/Plotly-style filter shape: each entry is `{ <name>: <arg> }`. Future
+// transforms (e.g. `abs`, `clamp`) slot in as additional union members.
 export type NodeFilter =
-  | { type: 'negate' };
+  | { multiply: number }
+  | { divide: number }
+  | { offset: number };
 
 export interface NodeInternal extends Node {
   children: ChildConfigOrStr[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,8 @@ export interface Node {
   name?: string;
   attribute?: string;
   unit_of_measurement?: string; // for attribute
+  entity_id?: string; // explicit entity to read; defaults to `id`. Lets a synthetic node id reference a real entity.
+  filters?: NodeFilter[]; // value transforms applied before the positive clamp.
   add_entities?: string[]; // temporary - will be replaced
   subtract_entities?: string[]; // temporary - will be replaced
   color?: string | {
@@ -104,6 +106,10 @@ export interface Link {
 }
 
 export type NodeType = 'entity' | 'passthrough' | 'remaining_parent_state' | 'remaining_child_state';
+
+// Discriminated union to keep future transforms (clamp, scale, abs, …) additive.
+export type NodeFilter =
+  | { type: 'negate' };
 
 export interface NodeInternal extends Node {
   children: ChildConfigOrStr[];


### PR DESCRIPTION
## Summary

Fixes #357
Fixes #170

In power-mode autoconfig (\`autoconfig.mode: power\`), battery charging and grid export were silently aggregated into the \"Unknown\" consumption node. HA's own power sankey reads a single signed \`stat_rate\` per source (positive = import/discharge, negative = export/charge); our chart already clamps negatives to 0 in [normalizeStateValue](src/utils.ts#L80), so the source side worked, but the negative half had nowhere to go.

This PR introduces a small, generally useful schema extension and uses it from autoconfig to surface the missing flows.

### `feat: add entity_id and filters to Node schema` #170

Two optional fields on `Node`:

- **\`entity_id\`** — explicit entity to read state from; defaults to \`id\`. Lets a synthetic node id reference a real entity, so two nodes can render the same entity from different angles.
- **\`filters\`** — discriminated-union list of value transforms applied *before* the existing positive clamp. Currently ships one type, \`{ type: 'negate' }\`. Combined with the clamp, this isolates the negative half of a signed sensor as a positive flow.

Documented in [README.md](README.md) (new \`Filters\` section + new rows in the Nodes object table).

### `fix(#357): show grid export and battery charge in power-mode autoconfig`

For each grid/battery source with a \`stat_rate\`, autoconfig now adds a sibling node \`\${stat_rate}__to_auto\` with \`entity_id: stat_rate\` and \`filters: [{ type: 'negate' }]\`. Dedup is by \`stat_rate\` — same rule as energy mode dedups by \`stat_energy_to\`.

Also fixes a latent dedup bug in **energy mode** where only the first battery got a charge node (was using \`sources.find(...)\` instead of \`filter().forEach()\`).

## Test plan

- [x] \`npm test\` — 83 tests pass (3 new power-mode tests, 1 new energy-mode multi-battery test, 1 new chart-level entity_id + negate test)
- [x] \`npm run lint\` — 0 errors (5 pre-existing warnings)
- [x] \`npm run build\` — clean
- [ ] Manual: load the dev card in HA with power-mode autoconfig and a signed grid/battery sensor; force the sensor through both signs (HA \`input_number\` helper works); confirm the export/charge node appears with \`--energy-grid-return-color\` / \`--energy-battery-in-color\` and the UNKNOWN node no longer absorbs the missing power.

## Notes for release-please

Two commits, two changelog entries:
- \`feat: add entity_id and filters to Node schema\`
- \`fix(#357): show grid export and battery charge in power-mode autoconfig\`