### PR TITLE
fix!(#234): layout entities left-to-right in vertical mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Install through [HACS](https://hacs.xyz/)
 | unit_prefix       | string  |                     | Metric prefix for the unit of measurment. See <https://en.wikipedia.org/wiki/Unit_prefix> . Supported values are m, k, M, G, T, and 'auto'. When 'auto' is used, the appropriate prefix is chosen automatically for each value based on its magnitude (m for values <1, k for values >=1000, etc.)
 | round             | number  | 0                   | Round the value to at most N decimal places. May not apply to near zero values, see issue [#29](https://github.com/MindFreeze/ha-sankey-chart/issues/29)
 | height            | number  | 200                 | The height of the card in pixels. Only matters while in horizontal layout. Vertical layout height is dynamic based on content
-| wide              | boolean | false               | Set this to true if you see extra empty space on the right side of the card. This will expand it horizontally to cover all the available space. Only relevant in horizontal mode.
 | show_icons        | boolean | false               | Display entity icons
 | show_names        | boolean | false               | Display entity names
 | show_states       | boolean | true                | Display entity states
@@ -288,7 +287,6 @@ time_period_to: "now/d"
   show_names: true
   unit_prefix: k
   round: 1
-  wide: true
   nodes:
     # Section 0 - Sources
     - id: sensor.solar

--- a/__tests__/__snapshots__/basic.test.ts.snap
+++ b/__tests__/__snapshots__/basic.test.ts.snap
@@ -37,9 +37,7 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
       </svg>
           </div>
       
-          <div class="spacerv" style="height:2.5px;"></div>
-          
-          <div class="box type-entity" style="height:195px;" title="2W ">
+          <div class="box type-entity" style="top:2.5px;height:195px;" title="2W ">
             <div style="background-color:var(--primary-color);" class="">
               
             </div>
@@ -50,16 +48,13 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
     
   </div>
           </div>
-          
         
     </div>
   
     <div class="section" style="">
       
       
-          
-          
-          <div class="box type-entity" style="height:97px;" title="1W ">
+          <div class="box type-entity" style="top:0px;height:97px;" title="1W ">
             <div style="background-color:var(--primary-color);" class="">
               
             </div>
@@ -70,11 +65,8 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
     
   </div>
           </div>
-          
         
-          <div class="spacerv" style="height:6px;"></div>
-          
-          <div class="box type-entity" style="height:97px;" title="1W ">
+          <div class="box type-entity" style="top:103px;height:97px;" title="1W ">
             <div style="background-color:var(--primary-color);" class="">
               
             </div>
@@ -85,7 +77,6 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
     
   </div>
           </div>
-          
         
     </div>
   
@@ -119,10 +110,7 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
         flex: initial;
     }
     .vertical .section {
-        display: flex;
         flex: initial;
-        flex-direction: row;
-        align-items: flex-start;
         max-width: 100%;
         width: 100%;
         height: 150px;
@@ -130,22 +118,21 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
     .vertical .section:last-child {
         flex: 1;
     }
-    .spacerv {
-        transition: height 0.25s;
-    }
-    .vertical .spacerv {
-        transition: width 0.25s;
-    }
     .box {
         display: flex;
         align-items: center;
-        /* position: relative; */
-        /* min-height: 1px; */
-        transition: height 0.25s;
+        position: absolute;
+        left: 0;
+        right: 0;
+        transition: top 0.25s, height 0.25s;
     }
     .vertical .box {
         flex-direction: column;
-        transition: width 0.25s;
+        left: auto;
+        right: auto;
+        top: 0;
+        bottom: 0;
+        transition: left 0.25s, width 0.25s;
     }
     /* .box::before {
         content: "";

--- a/__tests__/__snapshots__/basic.test.ts.snap
+++ b/__tests__/__snapshots__/basic.test.ts.snap
@@ -11,11 +11,11 @@ exports[`SankeyChart matches a simple snapshot 1`] = `
 exports[`SankeyChart matches a simple snapshot 2`] = `
 "
         <ha-card label="Sankey Chart">
-          <div class=" container " style="height:200px;">
-            
-    <div class="section" style="">
-      <div class="connectors">
-            <svg preserveAspectRatio="none" viewBox="0 0 100 200">
+          <div class=" container ">
+            <svg class="chart" preserveAspectRatio="xMinYMin meet" viewBox="0 0 992 200" width="992" height="200">
+              
+    <g class="section" transform="translate(0, 0)">
+      
         <defs>
           
             <linearGradient id="gradient0.0.0" gradientTransform="">
@@ -30,56 +30,68 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
           
         </defs>
         
-              <path d="M0,2.5 C50,2.5 50,0 100,0 L100,97 C50,97 50,100 0,100 Z" fill="url(#gradient0.0.0)" fill-opacity="0.4"></path>
+              <path d="M15,2.5 C477.85,2.5 477.85,0 940.7,0 L940.7,97 C477.85,97 477.85,100 15,100 Z" fill="url(#gradient0.0.0)" fill-opacity="0.4"></path>
             
-              <path d="M0,100 C50,100 50,103 100,103 L100,200 C50,200 50,197.5 0,197.5 Z" fill="url(#gradient0.0.1)" fill-opacity="0.4"></path>
+              <path d="M15,100 C477.85,100 477.85,103 940.7,103 L940.7,200 C477.85,200 477.85,197.5 15,197.5 Z" fill="url(#gradient0.0.1)" fill-opacity="0.4"></path>
             
-      </svg>
-          </div>
+      </g>
       
-          <div class="box type-entity" style="top:2.5px;height:195px;" title="2W ">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="2.5" width="15" height="195" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="2.5" width="925.7" height="195">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">W</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
-    <div class="section" style="">
+    <g class="section" transform="translate(940.7, 0)">
       
       
-          <div class="box type-entity" style="top:0px;height:97px;" title="1W ">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="0" width="15" height="97" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="0" width="36.3" height="97">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">W</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-          <div class="box type-entity" style="top:103px;height:97px;" title="1W ">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="103" width="15" height="97" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="103" width="36.3" height="97">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">W</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
+            </svg>
           </div>
         </ha-card>
       <style>
@@ -87,101 +99,75 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
         overflow-x: auto;
     }
     .container {
-        display: flex;
         position: relative;
-        /* height: 210px; */
         padding: 16px;
         overflow: hidden;
     }
     .container.with-header {
         margin-top: -16px;
     }
-    .container.vertical {
-        flex-direction: column;
-    }
-    .section {
-        flex: 1;
-        flex-direction: column;
-        position: relative;
-        min-width: 0;
-        max-width: 50%;
-    }
-    .wide .section:last-child {
-        flex: initial;
-    }
-    .vertical .section {
-        flex: initial;
+    .chart {
+        display: block;
         max-width: 100%;
-        width: 100%;
-        height: 150px;
-    }
-    .vertical .section:last-child {
-        flex: 1;
+        overflow: visible;
     }
     .box {
-        display: flex;
-        align-items: center;
-        position: absolute;
-        left: 0;
-        right: 0;
-        transition: top 0.25s, height 0.25s;
+        cursor: pointer;
     }
-    .vertical .box {
-        flex-direction: column;
-        left: auto;
-        right: auto;
-        top: 0;
-        bottom: 0;
-        transition: left 0.25s, width 0.25s;
+    .box .color-bar {
+        transition: x 0.25s, y 0.25s, width 0.25s, height 0.25s;
     }
-    /* .box::before {
-        content: "";
-        position: absolute;
-        top: -2px;
-        bottom: -2px;
-        left: -2px;
-        right: -2px;
-        background-color: var(--primary-color);
-        opacity: 0.5;
-        border-radius: 3px;
-    } */
-    .box div:first-child {
+    .box.type-passthrough .color-bar {
+        fill-opacity: 0.4;
+    }
+    .box.type-passthrough.hl .color-bar {
+        fill-opacity: 0.85;
+    }
+    foreignObject {
+        overflow: visible;
+        pointer-events: none;
+    }
+    .icon-wrap {
         display: flex;
         justify-content: center;
         align-items: center;
-        overflow: hidden;
-        background-color: var(--primary-color);
-        width: 15px;
-        height: 100%;
-        cursor: pointer;
-    }
-    .vertical .box div:first-child {
         width: 100%;
-        height: 15px;
+        height: 100%;
+        overflow: hidden;
     }
-    .box.type-passthrough div:first-child {
-        opacity: 0.4;
-    }
-    .box.type-passthrough div.hl:first-child {
-        opacity: 0.85;
-    }
-    .box .label {
-        flex: 1;
+    .label-wrap {
         display: flex;
         align-items: center;
+        width: 100%;
+        height: 100%;
+    }
+    .vertical .label-wrap {
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+    }
+    .box .label {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
         padding: 0 10px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        position: relative;
-        z-index: 1;
+        box-sizing: border-box;
+        pointer-events: auto;
     }
     .vertical .box .label {
         padding: 5px 0 0;
         flex-direction: column;
         white-space: normal;
-        /* word-break: break-all; */
         text-align: center;
+        max-width: none;
+        overflow: visible;
+        pointer-events: none;
+    }
+    .vertical .box .label > * {
+        pointer-events: auto;
     }
     .box .label .name {
         font-style: italic;
@@ -191,32 +177,7 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
         position: sticky;
         z-index: 100;
         color: var(--primary-text-color);
-    }
-    .connectors {
-        position: absolute;
-        top: 0;
-        left: 15px;
-        right: 0;
-        height: 100%;
-        overflow: hidden;
-    }
-    .vertical .connectors {
-        top: 15px;
-        left: 0;
-        bottom: 0;
-        height: auto;
-    }
-    .connectors svg {
-        position: absolute;
-        left: -1px;
-        width: 101%;
-        height: 100%;
-    }
-    .vertical .connectors svg {
-        top: -1px;
-        left: 0;
-        width: 100%;
-        height: 101%;
+        pointer-events: auto;
     }
 </style>"
 `;

--- a/__tests__/__snapshots__/basic.test.ts.snap
+++ b/__tests__/__snapshots__/basic.test.ts.snap
@@ -121,7 +121,7 @@ exports[`SankeyChart matches a simple snapshot 2`] = `
     .vertical .section {
         display: flex;
         flex: initial;
-        flex-direction: row-reverse;
+        flex-direction: row;
         align-items: flex-start;
         max-width: 100%;
         width: 100%;

--- a/__tests__/__snapshots__/remaining.test.ts.snap
+++ b/__tests__/__snapshots__/remaining.test.ts.snap
@@ -272,7 +272,7 @@ Blaa">
     .vertical .section {
         display: flex;
         flex: initial;
-        flex-direction: row-reverse;
+        flex-direction: row;
         align-items: flex-start;
         max-width: 100%;
         width: 100%;

--- a/__tests__/__snapshots__/remaining.test.ts.snap
+++ b/__tests__/__snapshots__/remaining.test.ts.snap
@@ -30,9 +30,7 @@ exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
       </svg>
           </div>
       
-          <div class="spacerv" style="height:69.5px;"></div>
-          
-          <div class="box type-entity" style="height:61px;" title="1.8kW Total">
+          <div class="box type-entity" style="top:69.5px;height:61px;" title="1.8kW Total">
             <div style="background-color:var(--warning-color);" class="">
               
             </div>
@@ -43,7 +41,6 @@ exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
     
   </div>
           </div>
-          
         
     </div>
   
@@ -78,9 +75,7 @@ exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
       </svg>
           </div>
       
-          <div class="spacerv" style="height:5px;"></div>
-          
-          <div class="box type-remaining_child_state" style="height:190px;" title="5.6kW Total
+          <div class="box type-remaining_child_state" style="top:5px;height:190px;" title="5.6kW Total
 All
 All
 All
@@ -105,7 +100,6 @@ IDK">
     
   </div>
           </div>
-          
         
     </div>
   
@@ -143,9 +137,7 @@ IDK">
       </svg>
           </div>
       
-          
-          
-          <div class="box type-entity" style="height:63px;" title="1.9kW Varmtvann
+          <div class="box type-entity" style="top:0px;height:63px;" title="1.9kW Varmtvann
 Blaa">
             <div style="background-color:var(--primary-color);" class="">
               
@@ -157,11 +149,8 @@ Blaa">
     
   </div>
           </div>
-          
         
-          <div class="spacerv" style="height:5.5px;"></div>
-          
-          <div class="box type-entity" style="height:63px;" title="1.9kВ Avfukter">
+          <div class="box type-entity" style="top:68.5px;height:63px;" title="1.9kВ Avfukter">
             <div style="background-color:var(--primary-color);" class="">
               
             </div>
@@ -172,11 +161,8 @@ Blaa">
     
   </div>
           </div>
-          
         
-          <div class="spacerv" style="height:5.5px;"></div>
-          
-          <div class="box type-entity" style="height:63px;" title="1.9kW ">
+          <div class="box type-entity" style="top:137px;height:63px;" title="1.9kW ">
             <div style="background-color:var(--primary-color);" class="">
               
             </div>
@@ -187,7 +173,6 @@ Blaa">
     
   </div>
           </div>
-          
         
     </div>
   
@@ -208,24 +193,19 @@ Blaa">
       </svg>
           </div>
       
-          <div class="spacerv" style="height:68.5px;"></div>
-          
-          <div class="box type-passthrough" style="height:63px;" title="1.9kW ">
+          <div class="box type-passthrough" style="top:68.5px;height:63px;" title="1.9kW ">
             <div style="background-color:red;" class="">
               
             </div>
             
           </div>
-          
         
     </div>
   
     <div class="section" style="">
       
       
-          <div class="spacerv" style="height:68.5px;"></div>
-          
-          <div class="box type-entity" style="height:63px;" title="1.9kW ">
+          <div class="box type-entity" style="top:68.5px;height:63px;" title="1.9kW ">
             <div style="background-color:red;" class="">
               
             </div>
@@ -236,7 +216,6 @@ Blaa">
     
   </div>
           </div>
-          
         
     </div>
   
@@ -270,10 +249,7 @@ Blaa">
         flex: initial;
     }
     .vertical .section {
-        display: flex;
         flex: initial;
-        flex-direction: row;
-        align-items: flex-start;
         max-width: 100%;
         width: 100%;
         height: 150px;
@@ -281,22 +257,21 @@ Blaa">
     .vertical .section:last-child {
         flex: 1;
     }
-    .spacerv {
-        transition: height 0.25s;
-    }
-    .vertical .spacerv {
-        transition: width 0.25s;
-    }
     .box {
         display: flex;
         align-items: center;
-        /* position: relative; */
-        /* min-height: 1px; */
-        transition: height 0.25s;
+        position: absolute;
+        left: 0;
+        right: 0;
+        transition: top 0.25s, height 0.25s;
     }
     .vertical .box {
         flex-direction: column;
-        transition: width 0.25s;
+        left: auto;
+        right: auto;
+        top: 0;
+        bottom: 0;
+        transition: left 0.25s, width 0.25s;
     }
     /* .box::before {
         content: "";

--- a/__tests__/__snapshots__/remaining.test.ts.snap
+++ b/__tests__/__snapshots__/remaining.test.ts.snap
@@ -11,11 +11,11 @@ exports[`SankeyChart with remaining type entities matches snapshot 1`] = `
 exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
 "
         <ha-card label="Sankey Chart">
-          <div class=" container with-header " style="height:200px;">
-            
-    <div class="section" style="">
-      <div class="connectors">
-            <svg preserveAspectRatio="none" viewBox="0 0 100 200">
+          <div class=" container with-header ">
+            <svg class="chart" preserveAspectRatio="xMinYMin meet" viewBox="0 0 992 200" width="992" height="200">
+              
+    <g class="section" transform="translate(0, 0)">
+      
         <defs>
           
             <linearGradient id="gradient0.0.0" gradientTransform="">
@@ -25,28 +25,30 @@ exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
           
         </defs>
         
-              <path d="M0,69.5 C50,69.5 50,5 100,5 L100,66.62162162162163 C50,66.62162162162163 50,130.5 0,130.5 Z" fill="url(#gradient0.0.0)" fill-opacity="0.4"></path>
+              <path d="M15,69.5 C122.03125,69.5 122.03125,5 229.0625,5 L229.0625,66.62162162162163 C122.03125,66.62162162162163 122.03125,130.5 15,130.5 Z" fill="url(#gradient0.0.0)" fill-opacity="0.4"></path>
             
-      </svg>
-          </div>
+      </g>
       
-          <div class="box type-entity" style="top:69.5px;height:61px;" title="1.8kW Total">
-            <div style="background-color:var(--warning-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="69.5" width="15" height="61" fill="var(--warning-color)"></rect>
+            
+            <foreignObject x="15" y="69.5" width="214.0625" height="61">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kW</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
-    <div class="section" style="">
-      <div class="connectors">
-            <svg preserveAspectRatio="none" viewBox="0 0 100 200">
+    <g class="section" transform="translate(229.0625, 0)">
+      
         <defs>
           
             <linearGradient id="gradient1.0.0" gradientTransform="">
@@ -66,16 +68,16 @@ exports[`SankeyChart with remaining type entities matches snapshot 2`] = `
           
         </defs>
         
-              <path d="M0,5 C50,5 50,0 100,0 L100,63 C50,63 50,68.2879899767317 0,68.2879899767317 Z" fill="url(#gradient1.0.0)" fill-opacity="0.4"></path>
+              <path d="M15,5 C122.03125,5 122.03125,0 229.0625,0 L229.0625,63 C122.03125,63 122.03125,68.2879899767317 15,68.2879899767317 Z" fill="url(#gradient1.0.0)" fill-opacity="0.4"></path>
             
-              <path d="M0,68.2879899767317 C50,68.2879899767317 50,68.5 100,68.5 L100,131.5 C50,131.5 50,131.60998747091463 0,131.60998747091463 Z" fill="url(#gradient1.0.1)" fill-opacity="0.4"></path>
+              <path d="M15,68.2879899767317 C122.03125,68.2879899767317 122.03125,68.5 229.0625,68.5 L229.0625,131.5 C122.03125,131.5 122.03125,131.60998747091463 15,131.60998747091463 Z" fill="url(#gradient1.0.1)" fill-opacity="0.4"></path>
             
-              <path d="M0,131.60998747091463 C50,131.60998747091463 50,137 100,137 L100,200 C50,200 50,195.00000000000003 0,195.00000000000003 Z" fill="url(#gradient1.0.2)" fill-opacity="0.4"></path>
+              <path d="M15,131.60998747091463 C122.03125,131.60998747091463 122.03125,137 229.0625,137 L229.0625,200 C122.03125,200 122.03125,195.00000000000003 15,195.00000000000003 Z" fill="url(#gradient1.0.2)" fill-opacity="0.4"></path>
             
-      </svg>
-          </div>
+      </g>
       
-          <div class="box type-remaining_child_state" style="top:5px;height:190px;" title="5.6kW Total
+          <g class=" box type-remaining_child_state ">
+            <title>5.6kW Total
 All
 All
 All
@@ -89,23 +91,25 @@ IDK
 IDK
 IDK
 IDK
-IDK">
-            <div style="background-color:darkslateblue;" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+IDK</title>
+            <rect class="color-bar" x="0" y="5" width="15" height="190" fill="darkslateblue"></rect>
+            
+            <foreignObject x="15" y="5" width="214.0625" height="190">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kW</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
-    <div class="section" style="">
-      <div class="connectors">
-            <svg preserveAspectRatio="none" viewBox="0 0 100 200">
+    <g class="section" transform="translate(458.125, 0)">
+      
         <defs>
           
             <linearGradient id="gradient2.0.0" gradientTransform="">
@@ -115,7 +119,7 @@ IDK">
           
         </defs>
         
-              <path d="M0,0 C50,0 50,68.5 100,68.5 L100,131.43236714975845 C50,131.43236714975845 50,63 0,63 Z" fill="url(#gradient2.0.0)" fill-opacity="0.4"></path>
+              <path d="M15,0 C122.03125,0 122.03125,68.5 229.0625,68.5 L229.0625,131.43236714975845 C122.03125,131.43236714975845 122.03125,63 15,63 Z" fill="url(#gradient2.0.0)" fill-opacity="0.4"></path>
             
       
         <defs>
@@ -127,58 +131,68 @@ IDK">
           
         </defs>
         
-              <path d="M0,68.5 C50,68.5 50,131.43236714975845 100,131.43236714975845 L100,131.5 C50,131.5 50,68.56766917293233 0,68.56766917293233 Z" fill="url(#gradient2.1.0)" fill-opacity="0.4"></path>
+              <path d="M15,68.5 C122.03125,68.5 122.03125,131.43236714975845 229.0625,131.43236714975845 L229.0625,131.5 C122.03125,131.5 122.03125,68.56766917293233 15,68.56766917293233 Z" fill="url(#gradient2.1.0)" fill-opacity="0.4"></path>
             
       
         <defs>
           
         </defs>
         
-      </svg>
-          </div>
+      </g>
       
-          <div class="box type-entity" style="top:0px;height:63px;" title="1.9kW Varmtvann
-Blaa">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title>1.9kW Varmtvann
+Blaa</title>
+            <rect class="color-bar" x="0" y="0" width="15" height="63" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="0" width="214.0625" height="63">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kW</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-          <div class="box type-entity" style="top:68.5px;height:63px;" title="1.9kВ Avfukter">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="68.5" width="15" height="63" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="68.5" width="214.0625" height="63">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kВ</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-          <div class="box type-entity" style="top:137px;height:63px;" title="1.9kW ">
-            <div style="background-color:var(--primary-color);" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="137" width="15" height="63" fill="var(--primary-color)"></rect>
+            
+            <foreignObject x="15" y="137" width="214.0625" height="63">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kW</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
-    <div class="section" style="">
-      <div class="connectors">
-            <svg preserveAspectRatio="none" viewBox="0 0 100 200">
+    <g class="section" transform="translate(687.1875, 0)">
+      
         <defs>
           
             <linearGradient id="gradient3.0.0" gradientTransform="">
@@ -188,37 +202,45 @@ Blaa">
           
         </defs>
         
-              <path d="M0,68.5 C50,68.5 50,68.5 100,68.5 L100,131.5 C50,131.5 50,131.5 0,131.5 Z" fill="url(#gradient3.0.0)" fill-opacity="0.4"></path>
+              <path d="M15,68.5 C122.03125,68.5 122.03125,68.5 229.0625,68.5 L229.0625,131.5 C122.03125,131.5 122.03125,131.5 15,131.5 Z" fill="url(#gradient3.0.0)" fill-opacity="0.4"></path>
             
-      </svg>
-          </div>
+      </g>
       
-          <div class="box type-passthrough" style="top:68.5px;height:63px;" title="1.9kW ">
-            <div style="background-color:red;" class="">
-              
-            </div>
+          <g class=" box type-passthrough ">
+            <title></title>
+            <rect class="color-bar" x="0" y="68.5" width="15" height="63" fill="red"></rect>
             
-          </div>
+            <foreignObject x="15" y="68.5" width="214.0625" height="63">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
-    <div class="section" style="">
+    <g class="section" transform="translate(916.25, 0)">
       
       
-          <div class="box type-entity" style="top:68.5px;height:63px;" title="1.9kW ">
-            <div style="background-color:red;" class="">
-              
-            </div>
-            <div class="label" style="line-height:15px;">
+          <g class=" box type-entity ">
+            <title></title>
+            <rect class="color-bar" x="0" y="68.5" width="15" height="63" fill="red"></rect>
+            
+            <foreignObject x="15" y="68.5" width="60.75" height="63">
+              <div class="label-wrap" xmlns="http://www.w3.org/1999/xhtml">
+                <div class="label" style="line-height:15px;">
     <span>
           <span class="state">kW</span>
         </span>
     
   </div>
-          </div>
+              </div>
+            </foreignObject>
+          </g>
         
-    </div>
+    </g>
   
+            </svg>
           </div>
         </ha-card>
       <style>
@@ -226,101 +248,75 @@ Blaa">
         overflow-x: auto;
     }
     .container {
-        display: flex;
         position: relative;
-        /* height: 210px; */
         padding: 16px;
         overflow: hidden;
     }
     .container.with-header {
         margin-top: -16px;
     }
-    .container.vertical {
-        flex-direction: column;
-    }
-    .section {
-        flex: 1;
-        flex-direction: column;
-        position: relative;
-        min-width: 0;
-        max-width: 50%;
-    }
-    .wide .section:last-child {
-        flex: initial;
-    }
-    .vertical .section {
-        flex: initial;
+    .chart {
+        display: block;
         max-width: 100%;
-        width: 100%;
-        height: 150px;
-    }
-    .vertical .section:last-child {
-        flex: 1;
+        overflow: visible;
     }
     .box {
-        display: flex;
-        align-items: center;
-        position: absolute;
-        left: 0;
-        right: 0;
-        transition: top 0.25s, height 0.25s;
+        cursor: pointer;
     }
-    .vertical .box {
-        flex-direction: column;
-        left: auto;
-        right: auto;
-        top: 0;
-        bottom: 0;
-        transition: left 0.25s, width 0.25s;
+    .box .color-bar {
+        transition: x 0.25s, y 0.25s, width 0.25s, height 0.25s;
     }
-    /* .box::before {
-        content: "";
-        position: absolute;
-        top: -2px;
-        bottom: -2px;
-        left: -2px;
-        right: -2px;
-        background-color: var(--primary-color);
-        opacity: 0.5;
-        border-radius: 3px;
-    } */
-    .box div:first-child {
+    .box.type-passthrough .color-bar {
+        fill-opacity: 0.4;
+    }
+    .box.type-passthrough.hl .color-bar {
+        fill-opacity: 0.85;
+    }
+    foreignObject {
+        overflow: visible;
+        pointer-events: none;
+    }
+    .icon-wrap {
         display: flex;
         justify-content: center;
         align-items: center;
-        overflow: hidden;
-        background-color: var(--primary-color);
-        width: 15px;
-        height: 100%;
-        cursor: pointer;
-    }
-    .vertical .box div:first-child {
         width: 100%;
-        height: 15px;
+        height: 100%;
+        overflow: hidden;
     }
-    .box.type-passthrough div:first-child {
-        opacity: 0.4;
-    }
-    .box.type-passthrough div.hl:first-child {
-        opacity: 0.85;
-    }
-    .box .label {
-        flex: 1;
+    .label-wrap {
         display: flex;
         align-items: center;
+        width: 100%;
+        height: 100%;
+    }
+    .vertical .label-wrap {
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+    }
+    .box .label {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
         padding: 0 10px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        position: relative;
-        z-index: 1;
+        box-sizing: border-box;
+        pointer-events: auto;
     }
     .vertical .box .label {
         padding: 5px 0 0;
         flex-direction: column;
         white-space: normal;
-        /* word-break: break-all; */
         text-align: center;
+        max-width: none;
+        overflow: visible;
+        pointer-events: none;
+    }
+    .vertical .box .label > * {
+        pointer-events: auto;
     }
     .box .label .name {
         font-style: italic;
@@ -330,32 +326,7 @@ Blaa">
         position: sticky;
         z-index: 100;
         color: var(--primary-text-color);
-    }
-    .connectors {
-        position: absolute;
-        top: 0;
-        left: 15px;
-        right: 0;
-        height: 100%;
-        overflow: hidden;
-    }
-    .vertical .connectors {
-        top: 15px;
-        left: 0;
-        bottom: 0;
-        height: auto;
-    }
-    .connectors svg {
-        position: absolute;
-        left: -1px;
-        width: 101%;
-        height: 100%;
-    }
-    .vertical .connectors svg {
-        top: -1px;
-        left: 0;
-        width: 100%;
-        height: 101%;
+        pointer-events: auto;
     }
 </style>"
 `;

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -430,9 +430,8 @@ export class Chart extends LitElement {
         statePerPixel: calcResults.statePerPixel,
         spacerSize: 0,
         config: section,
-        size: sectionSize,
         offset: 0,
-        width: 0,
+        size: 0,
       });
     });
 
@@ -484,30 +483,40 @@ export class Chart extends LitElement {
       const lastH = Math.min(MIN_VERTICAL_SECTION_H, this._naturalSectionHeight(last));
       let offset = 0;
       this.sections = this.sections.map((s, i) => {
-        const height = i === n - 1 ? lastH : MIN_VERTICAL_SECTION_H;
-        const updated = { ...s, offset, width: height };
-        offset += height;
+        const size = i === n - 1 ? lastH : MIN_VERTICAL_SECTION_H;
+        const updated = { ...s, offset, size };
+        offset += size;
         return updated;
       });
       return;
     }
 
     const chartW = this.width - 32;
+    const lastMin = last.config.min_width || 0;
     if (n === 1) {
-      this.sections = [{ ...last, offset: 0, width: chartW }];
+      this.sections = [{ ...last, offset: 0, size: Math.max(lastMin, chartW) }];
       return;
     }
 
+    const otherMinSum = this.sections
+      .slice(0, -1)
+      .reduce((sum, s) => sum + (s.config.min_width || 0), 0);
     const equalW = chartW / n;
-    const lastMin = last.config.min_width || 0;
-    const lastW = Math.max(lastMin, Math.min(equalW, this._naturalSectionWidth(last)));
-    const otherW = equalW + (equalW - lastW) / (n - 1);
+    const lastNatural = this._naturalSectionWidth(last);
+    // Last section: at least its min, at most equalW or its natural width.
+    // Also cap so the others can fit their own min_widths (if at all possible).
+    const lastCap = Math.max(lastMin, chartW - otherMinSum);
+    const lastW = Math.max(lastMin, Math.min(equalW, lastNatural, lastCap));
+
+    // Remaining width is distributed evenly on top of each other section's min_width.
+    // If the remainder is negative (mins exceed chartW), each section gets its min and the chart overflows.
+    const extra = Math.max(0, chartW - lastW - otherMinSum) / (n - 1);
 
     let offset = 0;
     this.sections = this.sections.map((s, i) => {
-      const width = i === n - 1 ? lastW : Math.max(s.config.min_width || 0, otherW);
-      const updated = { ...s, offset, width };
-      offset += width;
+      const size = i === n - 1 ? lastW : (s.config.min_width || 0) + extra;
+      const updated = { ...s, offset, size };
+      offset += size;
       return updated;
     });
   }
@@ -772,7 +781,7 @@ export class Chart extends LitElement {
       const chartW = this.width - 32;
       const lastSection = this.sections[this.sections.length - 1];
       const chartH = this.vertical
-        ? (lastSection ? lastSection.offset + lastSection.width : 0)
+        ? (lastSection ? lastSection.offset + lastSection.size : 0)
         : this.config.height;
 
       return html`

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -1,5 +1,4 @@
 import { LitElement, html, TemplateResult, PropertyValues, CSSResultGroup } from 'lit';
-import { styleMap } from 'lit/directives/style-map';
 import { classMap } from 'lit/directives/class-map';
 import { until } from 'lit/directives/until.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,7 +8,16 @@ import { HomeAssistant } from 'custom-card-helpers'; // This is a community main
 import type { Config, SectionState, Box, ConnectionState, EntityConfigInternal, NormalizedState } from './types';
 import { localize } from './localize/localize';
 import styles from './styles';
-import { getEntityId, normalizeStateValue, renderError, sortBoxes, generateRandomRGBColor } from './utils';
+import { formatState, getBoxName, getEntityId, normalizeStateValue, renderError, sortBoxes, generateRandomRGBColor } from './utils';
+import {
+  BOX_COLOR_BAR,
+  CHAR_WIDTH_RATIO,
+  LABEL_PADDING,
+  MIN_LABEL_HEIGHT,
+  MIN_VERTICAL_SECTION_H,
+  NAME_CHAR_WIDTH,
+  SEPARATOR_WIDTH,
+} from './const';
 import { HassEntities, HassEntity } from 'home-assistant-js-websocket';
 import { handleAction } from './handle-actions';
 import { filterConfigByZoomEntity } from './zoom';
@@ -423,6 +431,8 @@ export class Chart extends LitElement {
         spacerSize: 0,
         config: section,
         size: sectionSize,
+        offset: 0,
+        width: 0,
       });
     });
 
@@ -461,6 +471,82 @@ export class Chart extends LitElement {
         spacerSize,
       };
     });
+
+    this._calcSectionLayout();
+  }
+
+  private _calcSectionLayout() {
+    const n = this.sections.length;
+    if (!n) return;
+    const last = this.sections[n - 1];
+
+    if (this.vertical) {
+      const lastH = Math.min(MIN_VERTICAL_SECTION_H, this._naturalSectionHeight(last));
+      let offset = 0;
+      this.sections = this.sections.map((s, i) => {
+        const height = i === n - 1 ? lastH : MIN_VERTICAL_SECTION_H;
+        const updated = { ...s, offset, width: height };
+        offset += height;
+        return updated;
+      });
+      return;
+    }
+
+    const chartW = this.width - 32;
+    if (n === 1) {
+      this.sections = [{ ...last, offset: 0, width: chartW }];
+      return;
+    }
+
+    const equalW = chartW / n;
+    const lastMin = last.config.min_width || 0;
+    const lastW = Math.max(lastMin, Math.min(equalW, this._naturalSectionWidth(last)));
+    const otherW = equalW + (equalW - lastW) / (n - 1);
+
+    let offset = 0;
+    this.sections = this.sections.map((s, i) => {
+      const width = i === n - 1 ? lastW : Math.max(s.config.min_width || 0, otherW);
+      const updated = { ...s, offset, width };
+      offset += width;
+      return updated;
+    });
+  }
+
+  private _naturalSectionHeight(section: SectionState): number {
+    const { show_states, show_names } = this.config;
+    let nameLines = 0;
+    if (show_names) {
+      for (const box of section.boxes) {
+        if (box.config.type === 'passthrough') continue;
+        const name = getBoxName(box);
+        const explicit = name.split('\n').filter(Boolean).length;
+        const wordCount = name.split(/\s+/).filter(Boolean).length;
+        const lines = Math.max(explicit, wordCount, 1);
+        nameLines = Math.max(nameLines, lines);
+      }
+    }
+    const stateLines = show_states ? 1 : 0;
+    const totalLines = stateLines + nameLines;
+    if (!totalLines) return BOX_COLOR_BAR;
+    return BOX_COLOR_BAR + 5 + totalLines * MIN_LABEL_HEIGHT;
+  }
+
+  private _naturalSectionWidth(section: SectionState): number {
+    const { show_states, show_names, show_units, round, monetary_unit } = this.config;
+    let maxWidth = 0;
+    for (const box of section.boxes) {
+      if (box.config.type === 'passthrough') continue;
+      const stateText = show_states
+        ? formatState(box.state, round, this.hass.locale, monetary_unit) + (show_units ? box.unit_of_measurement || '' : '')
+        : '';
+      const nameText = show_names ? getBoxName(box) : '';
+      const stateW = stateText.length * CHAR_WIDTH_RATIO;
+      const nameW = nameText.length * NAME_CHAR_WIDTH;
+      const separatorW = stateText && nameText ? SEPARATOR_WIDTH : 0;
+      const labelW = stateW + separatorW + nameW + 2 * LABEL_PADDING;
+      maxWidth = Math.max(maxWidth, BOX_COLOR_BAR + labelW);
+    }
+    return maxWidth;
   }
 
   private _calcBoxHeights(
@@ -665,17 +751,14 @@ export class Chart extends LitElement {
       this.reconciledStates.clear();
       const containerClasses = classMap({
         container: true,
-        wide: !!this.config.wide,
         'with-header': !!this.config.title,
         vertical: this.vertical,
       });
 
-      const height = this.vertical ? 'auto' : this.config.height + 'px';
-
       if (!Object.keys(this.states).length) {
         return html`
           <ha-card label="Sankey Chart" .header=${this.config.title}>
-            <div class=${containerClasses} style=${styleMap({ height: height })}>${localize('common.loading')}</div>
+            <div class=${containerClasses}>${localize('common.loading')}</div>
           </ha-card>
         `;
       }
@@ -686,25 +769,39 @@ export class Chart extends LitElement {
 
       this.lastUpdate = Date.now();
 
+      const chartW = this.width - 32;
+      const lastSection = this.sections[this.sections.length - 1];
+      const chartH = this.vertical
+        ? (lastSection ? lastSection.offset + lastSection.width : 0)
+        : this.config.height;
+
       return html`
         <ha-card label="Sankey Chart" .header=${this.config.title}>
-          <div class=${containerClasses} style=${styleMap({ height: height })}>
-            ${this.sections.map((s, i) =>
-              renderSection({
-                locale: this.hass.locale,
-                config: this.config,
-                section: s,
-                nextSection: this.sections[i + 1],
-                sectionIndex: i,
-                highlightedEntities: this.highlightedEntities,
-                allConnections: this.connections,
-                onTap: this._handleBoxTap.bind(this),
-                onDoubleTap: this._handleBoxDoubleTap.bind(this),
-                onMouseEnter: this._handleMouseEnter.bind(this),
-                onMouseLeave: this._handleMouseLeave.bind(this),
-                vertical: this.vertical,
-              }),
-            )}
+          <div class=${containerClasses}>
+            <svg
+              class="chart"
+              viewBox="0 0 ${chartW} ${chartH}"
+              width="${chartW}"
+              height="${chartH}"
+              preserveAspectRatio="xMinYMin meet"
+            >
+              ${this.sections.map((s, i) =>
+                renderSection({
+                  locale: this.hass.locale,
+                  config: this.config,
+                  section: s,
+                  nextSection: this.sections[i + 1],
+                  sectionIndex: i,
+                  highlightedEntities: this.highlightedEntities,
+                  allConnections: this.connections,
+                  onTap: this._handleBoxTap.bind(this),
+                  onDoubleTap: this._handleBoxDoubleTap.bind(this),
+                  onMouseEnter: this._handleMouseEnter.bind(this),
+                  onMouseLeave: this._handleMouseLeave.bind(this),
+                  vertical: this.vertical,
+                }),
+              )}
+            </svg>
           </div>
         </ha-card>
       `;

--- a/src/const.ts
+++ b/src/const.ts
@@ -10,6 +10,11 @@ export const UNIT_PREFIXES = {
 
 export const MIN_LABEL_HEIGHT = 15;
 export const CHAR_WIDTH_RATIO = 8.15; // px per char, trial and error
+export const NAME_CHAR_WIDTH = 6; // proportional/italic name text is narrower
+export const SEPARATOR_WIDTH = 4; // nbsp between state and name
+export const LABEL_PADDING = 10; // .label has padding: 0 10px
+
+export const BOX_COLOR_BAR = 15; // width/height of the colored bar on each box
 
 export const MIN_HORIZONTAL_SECTION_W = 150;
 export const MIN_VERTICAL_SECTION_H = 150;

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -275,7 +275,6 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
               },
             },
           },
-          { name: 'wide', selector: { boolean: {} } },
           { name: 'height', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
           { name: 'min_box_size', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
           { name: 'min_box_distance', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },

--- a/src/label.ts
+++ b/src/label.ts
@@ -15,9 +15,8 @@ export function renderLabel(
   const shouldShowLabel = box.config.type !== 'passthrough' && (show_names || show_states);
   if (!shouldShowLabel) return null;
 
-  const maxLabelSize = box.size + spacerSize - 1;
+  const maxLabelSize = box.size + spacerSize - 2;
 
-  // reduce label size if it doesn't fit
   const labelStyle: Record<string, string> = { lineHeight: MIN_LABEL_HEIGHT + 'px' };
   const nameStyle: Record<string, string> = {};
   if (vertical) {
@@ -26,35 +25,35 @@ export function renderLabel(
     const stateChars = (formattedState + (show_units ? box.unit_of_measurement : '')).length;
     const desiredWidth = stateChars * CHAR_WIDTH_RATIO;
     if (desiredWidth > maxLabelSize) {
-      const fontSize = maxLabelSize / desiredWidth;
-      labelStyle.fontSize = `${fontSize}em`;
-      labelStyle.lineHeight = `${fontSize}em`;
+      const fontSize = (maxLabelSize / desiredWidth) * MIN_LABEL_HEIGHT;
+      labelStyle.fontSize = `${fontSize}px`;
+      labelStyle.lineHeight = `${fontSize}px`;
     }
     if (show_names) {
       const nameChars = Math.max(...name.split(/[\s]+/).map(l => l.length));
       const desiredNameWidth = nameChars * CHAR_WIDTH_RATIO;
       if (desiredNameWidth > maxLabelSize) {
-        const fontSize = maxLabelSize / desiredNameWidth;
-        nameStyle.fontSize = `${fontSize}rem`;
-        nameStyle.lineHeight = `${fontSize}rem`;
+        const fontSize = (maxLabelSize / desiredNameWidth) * MIN_LABEL_HEIGHT;
+        nameStyle.fontSize = `${fontSize}px`;
+        nameStyle.lineHeight = `${fontSize}px`;
       }
     }
   } else {
     if (maxLabelSize < MIN_LABEL_HEIGHT) {
-      const fontSize = maxLabelSize / MIN_LABEL_HEIGHT;
-      // labelStyle.maxHeight = maxLabelSize + 'px';
-      labelStyle.fontSize = `${fontSize}em`;
-      labelStyle.lineHeight = `${fontSize}em`;
+      labelStyle.fontSize = `${maxLabelSize}px`;
+      labelStyle.lineHeight = `${maxLabelSize}px`;
     }
     const numLines = name.split('\n').filter(v => v).length;
     if (numLines > 1) {
       nameStyle.whiteSpace = 'pre';
       if (labelStyle.fontSize) {
-        nameStyle.fontSize = `${1 / numLines + 0.1}rem`;
-        nameStyle.lineHeight = `${1 / numLines + 0.1}rem`;
+        const baseLabelSize = maxLabelSize < MIN_LABEL_HEIGHT ? maxLabelSize : MIN_LABEL_HEIGHT;
+        nameStyle.fontSize = `${baseLabelSize * (1 / numLines + 0.1)}px`;
+        nameStyle.lineHeight = `${baseLabelSize * (1 / numLines + 0.1)}px`;
       } else if (maxLabelSize < MIN_LABEL_HEIGHT * numLines) {
-        nameStyle.fontSize = `${(maxLabelSize / MIN_LABEL_HEIGHT / numLines) * 1.1}em`;
-        nameStyle.lineHeight = `${(maxLabelSize / MIN_LABEL_HEIGHT / numLines) * 1.1}em`;
+        const fontSize = (maxLabelSize / numLines) * 1.1;
+        nameStyle.fontSize = `${fontSize}px`;
+        nameStyle.lineHeight = `${fontSize}px`;
       }
     }
   }

--- a/src/section.ts
+++ b/src/section.ts
@@ -17,9 +17,9 @@ export function renderBranchConnectors(props: {
   allConnections: ConnectionState[];
   vertical: boolean;
 }): SVGTemplateResult[] {
-  const { boxes, width } = props.section;
+  const { boxes, size } = props.section;
   const nearEdge = BOX_COLOR_BAR;
-  const farEdge = width;
+  const farEdge = size;
   const midEdge = (nearEdge + farEdge) / 2;
   return boxes
     .filter(b => b.children.length > 0)
@@ -82,7 +82,7 @@ export function renderSection(props: {
   onMouseLeave: () => void;
 }) {
   const { show_icons } = props.config;
-  const { boxes, spacerSize, offset, width } = props.section;
+  const { boxes, spacerSize, offset, size } = props.section;
   const hasChildren = props.nextSection && boxes.some(b => b.children.length > 0);
   const sectionTransform = props.vertical
     ? `translate(0, ${offset})`
@@ -108,8 +108,8 @@ export function renderSection(props: {
           ? { x: box.top, y: 0, width: box.size, height: BOX_COLOR_BAR }
           : { x: 0, y: box.top, width: BOX_COLOR_BAR, height: box.size };
         const labelArea = props.vertical
-          ? { x: box.top, y: BOX_COLOR_BAR, width: box.size, height: width - BOX_COLOR_BAR }
-          : { x: BOX_COLOR_BAR, y: box.top, width: width - BOX_COLOR_BAR, height: box.size };
+          ? { x: box.top, y: BOX_COLOR_BAR, width: box.size, height: size - BOX_COLOR_BAR }
+          : { x: BOX_COLOR_BAR, y: box.top, width: size - BOX_COLOR_BAR, height: box.size };
 
         const classes = classMap({
           box: true,

--- a/src/section.ts
+++ b/src/section.ts
@@ -14,7 +14,7 @@ export function renderBranchConnectors(props: {
   allConnections: ConnectionState[];
   vertical: boolean;
 }): SVGTemplateResult[] {
-  const { boxes, size } = props.section;
+  const { boxes } = props.section;
   return boxes
     .filter(b => b.children.length > 0)
     .map((b, boxIndex) => {
@@ -51,7 +51,7 @@ export function renderBranchConnectors(props: {
             ['', 0, c.startY + c.startSize],
           ];
           if (props.vertical) {
-            coords = coords.map(c => [c[0], size - (c[2] as number), c[1]]);
+            coords = coords.map(c => [c[0], c[2] as number, c[1]]);
           }
           return svg`
               <path d="${coords.map(([cmd, x, y]) => `${cmd}${x},${y}`).join(' ')} Z"

--- a/src/section.ts
+++ b/src/section.ts
@@ -98,7 +98,7 @@ export function renderSection(props: {
           </div>`
         : null}
       ${boxes.map(box => {
-        const { entity, extraSpacers } = box;
+        const { entity } = box;
         if (props.config.unit_prefix === 'auto') {
           box = { ...box, ...normalizeStateValue(props.config.unit_prefix, box.state, box.unit_of_measurement, true) };
         }
@@ -107,16 +107,14 @@ export function renderSection(props: {
         const name = box.config.name || entity.attributes.friendly_name || '';
         const icon = box.config.icon || stateIcon(entity as HassEntity);
 
-        const sizeProp = props.vertical ? 'width' : 'height';
+        const boxStyle = props.vertical
+          ? { left: box.top + 'px', width: box.size + 'px' }
+          : { top: box.top + 'px', height: box.size + 'px' };
 
         return html`
-          ${box.top > 0 ? html`<div class="spacerv" style=${styleMap({ [sizeProp]: spacerSize + 'px' })}></div>` : null}
-          ${extraSpacers
-            ? html`<div class="spacerv" style=${styleMap({ [sizeProp]: extraSpacers + 'px' })}></div>`
-            : null}
           <div
             class=${'box type-' + box.config.type!}
-            style=${styleMap({ [sizeProp]: box.size + 'px' })}
+            style=${styleMap(boxStyle)}
             @click=${() => props.onTap(box)}
             @dblclick=${() => props.onDoubleTap(box)}
             @mouseenter=${() => props.onMouseEnter(box)}
@@ -133,7 +131,6 @@ export function renderSection(props: {
             </div>
             ${renderLabel(box, props.config, formattedState, name, spacerSize, props.vertical)}
           </div>
-          ${extraSpacers ? html`<div class="spacerv" style=${styleMap({ height: extraSpacers + 'px' })}></div>` : null}
         `;
       })}
     </div>

--- a/src/section.ts
+++ b/src/section.ts
@@ -1,11 +1,14 @@
 import { html, svg, SVGTemplateResult } from 'lit';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { classMap } from 'lit/directives/class-map';
 import { styleMap } from 'lit/directives/style-map';
 import { Box, Config, ConnectionState, EntityConfigInternal, SectionState } from './types';
-import { formatState, getChildConnections, getEntityId, normalizeStateValue } from './utils';
+import { formatState, getBoxName, getChildConnections, getEntityId, normalizeStateValue } from './utils';
 import { FrontendLocaleData, stateIcon } from 'custom-card-helpers';
 import { HassEntity } from 'home-assistant-js-websocket';
 import { renderLabel } from './label';
+import { BOX_COLOR_BAR } from './const';
+
+const XHTML_NS = 'http://www.w3.org/1999/xhtml';
 
 export function renderBranchConnectors(props: {
   section: SectionState;
@@ -14,7 +17,10 @@ export function renderBranchConnectors(props: {
   allConnections: ConnectionState[];
   vertical: boolean;
 }): SVGTemplateResult[] {
-  const { boxes } = props.section;
+  const { boxes, width } = props.section;
+  const nearEdge = BOX_COLOR_BAR;
+  const farEdge = width;
+  const midEdge = (nearEdge + farEdge) / 2;
   return boxes
     .filter(b => b.children.length > 0)
     .map((b, boxIndex) => {
@@ -22,9 +28,7 @@ export function renderBranchConnectors(props: {
         b.children.some(c => getEntityId(c) === child.id),
       );
       const connections = getChildConnections(b, children, props.allConnections).filter(
-        c => {
-          return c.state > 0;
-        },
+        c => c.state > 0,
       );
       return svg`
         <defs>
@@ -40,19 +44,18 @@ export function renderBranchConnectors(props: {
           )}
         </defs>
         ${connections.map((c, i) => {
-          let coords = [
-            ['M', 0, c.startY],
-            ['C', 50, c.startY],
-            ['', 50, c.endY],
-            ['', 100, c.endY],
-            ['L', 100, c.endY + c.endSize],
-            ['C', 50, c.endY + c.endSize],
-            ['', 50, c.startY + c.startSize],
-            ['', 0, c.startY + c.startSize],
+          const pt = (along: number, across: number): [number, number] =>
+            props.vertical ? [along, across] : [across, along];
+          const coords: [string, number, number][] = [
+            ['M', ...pt(c.startY, nearEdge)],
+            ['C', ...pt(c.startY, midEdge)],
+            ['', ...pt(c.endY, midEdge)],
+            ['', ...pt(c.endY, farEdge)],
+            ['L', ...pt(c.endY + c.endSize, farEdge)],
+            ['C', ...pt(c.endY + c.endSize, midEdge)],
+            ['', ...pt(c.startY + c.startSize, midEdge)],
+            ['', ...pt(c.startY + c.startSize, nearEdge)],
           ];
-          if (props.vertical) {
-            coords = coords.map(c => [c[0], c[2] as number, c[1]]);
-          }
           return svg`
               <path d="${coords.map(([cmd, x, y]) => `${cmd}${x},${y}`).join(' ')} Z"
                 fill="url(#gradient${props.sectionIndex}.${boxIndex}.${i})" fill-opacity="${
@@ -79,23 +82,16 @@ export function renderSection(props: {
   onMouseLeave: () => void;
 }) {
   const { show_icons } = props.config;
-  const {
-    boxes,
-    spacerSize,
-    config: { min_width },
-    size,
-  } = props.section;
+  const { boxes, spacerSize, offset, width } = props.section;
   const hasChildren = props.nextSection && boxes.some(b => b.children.length > 0);
+  const sectionTransform = props.vertical
+    ? `translate(0, ${offset})`
+    : `translate(${offset}, 0)`;
 
-  const viewBox = props.vertical ? `0 0 ${size} 100` : `0 0 100 ${size}`;
-  const minWidth = min_width && !props.vertical ? min_width + 'px' : undefined;
-
-  return html`
-    <div class="section" style=${styleMap({ minWidth })}>
+  return svg`
+    <g class="section" transform="${sectionTransform}">
       ${hasChildren
-        ? html`<div class="connectors">
-            <svg viewBox="${viewBox}" preserveAspectRatio="none">${renderBranchConnectors(props)}</svg>
-          </div>`
+        ? svg`<g class="connectors">${renderBranchConnectors(props)}</g>`
         : null}
       ${boxes.map(box => {
         const { entity } = box;
@@ -104,35 +100,57 @@ export function renderSection(props: {
         }
         const formattedState = formatState(box.state, props.config.round, props.locale, props.config.monetary_unit);
         const isNotPassthrough = box.config.type !== 'passthrough';
-        const name = box.config.name || entity.attributes.friendly_name || '';
+        const name = getBoxName(box);
         const icon = box.config.icon || stateIcon(entity as HassEntity);
+        const isHighlighted = props.highlightedEntities.includes(box.config);
 
-        const boxStyle = props.vertical
-          ? { left: box.top + 'px', width: box.size + 'px' }
-          : { top: box.top + 'px', height: box.size + 'px' };
+        const colorRect = props.vertical
+          ? { x: box.top, y: 0, width: box.size, height: BOX_COLOR_BAR }
+          : { x: 0, y: box.top, width: BOX_COLOR_BAR, height: box.size };
+        const labelArea = props.vertical
+          ? { x: box.top, y: BOX_COLOR_BAR, width: box.size, height: width - BOX_COLOR_BAR }
+          : { x: BOX_COLOR_BAR, y: box.top, width: width - BOX_COLOR_BAR, height: box.size };
 
-        return html`
-          <div
-            class=${'box type-' + box.config.type!}
-            style=${styleMap(boxStyle)}
+        const classes = classMap({
+          box: true,
+          ['type-' + box.config.type!]: true,
+          hl: isHighlighted,
+        });
+
+        return svg`
+          <g
+            class=${classes}
             @click=${() => props.onTap(box)}
             @dblclick=${() => props.onDoubleTap(box)}
             @mouseenter=${() => props.onMouseEnter(box)}
             @mouseleave=${props.onMouseLeave}
-            title=${formattedState + box.unit_of_measurement + ' ' + name}
           >
-            <div
-              style=${styleMap({ backgroundColor: box.color })}
-              class=${props.highlightedEntities.includes(box.config) ? 'hl' : ''}
-            >
-              ${show_icons && isNotPassthrough
-                ? html`<ha-icon .icon=${icon} style=${styleMap({ transform: 'scale(0.65)' })}></ha-icon>`
-                : null}
-            </div>
-            ${renderLabel(box, props.config, formattedState, name, spacerSize, props.vertical)}
-          </div>
+            <title>${formattedState + box.unit_of_measurement + ' ' + name}</title>
+            <rect class="color-bar"
+              x="${colorRect.x}" y="${colorRect.y}"
+              width="${colorRect.width}" height="${colorRect.height}"
+              fill="${box.color}"></rect>
+            ${show_icons && isNotPassthrough
+              ? svg`
+                <foreignObject
+                  x="${colorRect.x}" y="${colorRect.y}"
+                  width="${colorRect.width}" height="${colorRect.height}">
+                  ${html`<div xmlns="${XHTML_NS}" class="icon-wrap">
+                    <ha-icon .icon=${icon} style=${styleMap({ transform: 'scale(0.65)' })}></ha-icon>
+                  </div>`}
+                </foreignObject>
+              `
+              : null}
+            <foreignObject
+              x="${labelArea.x}" y="${labelArea.y}"
+              width="${labelArea.width}" height="${labelArea.height}">
+              ${html`<div xmlns="${XHTML_NS}" class="label-wrap">
+                ${renderLabel(box, props.config, formattedState, name, spacerSize, props.vertical)}
+              </div>`}
+            </foreignObject>
+          </g>
         `;
       })}
-    </div>
+    </g>
   `;
 }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -30,10 +30,7 @@ export default css`
         flex: initial;
     }
     .vertical .section {
-        display: flex;
         flex: initial;
-        flex-direction: row;
-        align-items: flex-start;
         max-width: 100%;
         width: 100%;
         height: ${unsafeCSS(MIN_VERTICAL_SECTION_H + 'px')};
@@ -41,22 +38,21 @@ export default css`
     .vertical .section:last-child {
         flex: 1;
     }
-    .spacerv {
-        transition: height 0.25s;
-    }
-    .vertical .spacerv {
-        transition: width 0.25s;
-    }
     .box {
         display: flex;
         align-items: center;
-        /* position: relative; */
-        /* min-height: 1px; */
-        transition: height 0.25s;
+        position: absolute;
+        left: 0;
+        right: 0;
+        transition: top 0.25s, height 0.25s;
     }
     .vertical .box {
         flex-direction: column;
-        transition: width 0.25s;
+        left: auto;
+        right: auto;
+        top: 0;
+        bottom: 0;
+        transition: left 0.25s, width 0.25s;
     }
     /* .box::before {
         content: "";

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,5 +1,4 @@
-import { css, unsafeCSS } from 'lit';
-import { MIN_VERTICAL_SECTION_H } from './const';
+import { css } from 'lit';
 
 // https://lit.dev/docs/components/styles/
 export default css`
@@ -7,101 +6,75 @@ export default css`
         overflow-x: auto;
     }
     .container {
-        display: flex;
         position: relative;
-        /* height: 210px; */
         padding: 16px;
         overflow: hidden;
     }
     .container.with-header {
         margin-top: -16px;
     }
-    .container.vertical {
-        flex-direction: column;
-    }
-    .section {
-        flex: 1;
-        flex-direction: column;
-        position: relative;
-        min-width: 0;
-        max-width: 50%;
-    }
-    .wide .section:last-child {
-        flex: initial;
-    }
-    .vertical .section {
-        flex: initial;
+    .chart {
+        display: block;
         max-width: 100%;
-        width: 100%;
-        height: ${unsafeCSS(MIN_VERTICAL_SECTION_H + 'px')};
-    }
-    .vertical .section:last-child {
-        flex: 1;
+        overflow: visible;
     }
     .box {
-        display: flex;
-        align-items: center;
-        position: absolute;
-        left: 0;
-        right: 0;
-        transition: top 0.25s, height 0.25s;
+        cursor: pointer;
     }
-    .vertical .box {
-        flex-direction: column;
-        left: auto;
-        right: auto;
-        top: 0;
-        bottom: 0;
-        transition: left 0.25s, width 0.25s;
+    .box .color-bar {
+        transition: x 0.25s, y 0.25s, width 0.25s, height 0.25s;
     }
-    /* .box::before {
-        content: "";
-        position: absolute;
-        top: -2px;
-        bottom: -2px;
-        left: -2px;
-        right: -2px;
-        background-color: var(--primary-color);
-        opacity: 0.5;
-        border-radius: 3px;
-    } */
-    .box div:first-child {
+    .box.type-passthrough .color-bar {
+        fill-opacity: 0.4;
+    }
+    .box.type-passthrough.hl .color-bar {
+        fill-opacity: 0.85;
+    }
+    foreignObject {
+        overflow: visible;
+        pointer-events: none;
+    }
+    .icon-wrap {
         display: flex;
         justify-content: center;
         align-items: center;
-        overflow: hidden;
-        background-color: var(--primary-color);
-        width: 15px;
-        height: 100%;
-        cursor: pointer;
-    }
-    .vertical .box div:first-child {
         width: 100%;
-        height: 15px;
+        height: 100%;
+        overflow: hidden;
     }
-    .box.type-passthrough div:first-child {
-        opacity: 0.4;
-    }
-    .box.type-passthrough div.hl:first-child {
-        opacity: 0.85;
-    }
-    .box .label {
-        flex: 1;
+    .label-wrap {
         display: flex;
         align-items: center;
+        width: 100%;
+        height: 100%;
+    }
+    .vertical .label-wrap {
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+    }
+    .box .label {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
         padding: 0 10px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        position: relative;
-        z-index: 1;
+        box-sizing: border-box;
+        pointer-events: auto;
     }
     .vertical .box .label {
         padding: 5px 0 0;
         flex-direction: column;
         white-space: normal;
-        /* word-break: break-all; */
         text-align: center;
+        max-width: none;
+        overflow: visible;
+        pointer-events: none;
+    }
+    .vertical .box .label > * {
+        pointer-events: auto;
     }
     .box .label .name {
         font-style: italic;
@@ -111,31 +84,6 @@ export default css`
         position: sticky;
         z-index: 100;
         color: var(--primary-text-color);
-    }
-    .connectors {
-        position: absolute;
-        top: 0;
-        left: 15px;
-        right: 0;
-        height: 100%;
-        overflow: hidden;
-    }
-    .vertical .connectors {
-        top: 15px;
-        left: 0;
-        bottom: 0;
-        height: auto;
-    }
-    .connectors svg {
-        position: absolute;
-        left: -1px;
-        width: 101%;
-        height: 100%;
-    }
-    .vertical .connectors svg {
-        top: -1px;
-        left: 0;
-        width: 100%;
-        height: 101%;
+        pointer-events: auto;
     }
 `;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -32,7 +32,7 @@ export default css`
     .vertical .section {
         display: flex;
         flex: initial;
-        flex-direction: row-reverse;
+        flex-direction: row;
         align-items: flex-start;
         max-width: 100%;
         width: 100%;

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,7 +232,6 @@ export interface SectionState {
   config: Section;
   size: number;
   offset: number;
-  width: number;
 }
 
 export interface ConnectionState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,6 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
   unit_prefix?: '' | 'auto' | keyof typeof UNIT_PREFIXES;
   round?: number;
   height?: number;
-  wide?: boolean;
   layout?: 'auto' | 'vertical' | 'horizontal';
   show_icons?: boolean;
   show_names?: boolean;
@@ -232,6 +231,8 @@ export interface SectionState {
   statePerPixel: number;
   config: Section;
   size: number;
+  offset: number;
+  width: number;
 }
 
 export interface ConnectionState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,7 +219,6 @@ export interface Box {
   color: string;
   size: number;
   top: number;
-  extraSpacers?: number;
   connections: {
     parents: Connection[];
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,6 +129,10 @@ export function getEntityId(entity: string | Node | Record<string, unknown>): st
   return typeof entity === 'string' ? entity : ((entity.id || (entity as Record<string, unknown>).entity_id) as string);
 }
 
+export function getBoxName(box: Box): string {
+  return box.config.name || box.entity.attributes.friendly_name || '';
+}
+
 export function getChildConnections(
   parent: Box,
   children: Box[],


### PR DESCRIPTION
## Summary

- Fixes [#234](https://github.com/MindFreeze/ha-sankey-chart/issues/234): vertical-layout entities now render in definition order (left-to-right) instead of reversed.
- Replaces the per-section DOM divs + per-section connector SVGs with **one chart-wide SVG**. Boxes (`<rect>` + `<foreignObject>` for the label) and connector paths now share a single coordinate system, eliminating subpixel misalignment between box edges and connector ends.
- Sections become virtual: each is a `<g transform="translate(...)">` for positioning math only, no DOM div per section.
- **Auto-shrinks the last section** to fit its label content and redistributes the freed width to the other sections (horizontal mode), and shrinks the last section's height in vertical mode. Removes the now-redundant `wide` config option.

## Breaking change

The `wide` config option has been removed. Existing configs continue to load (the field is silently ignored); the new auto-shrink default replaces what `wide: true` used to do.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 83/83 passing (snapshots regenerated)
- [x] Manual verification in browser, vertical layout: entities render left-to-right in definition order; connector edges meet box edges pixel-perfect.
- [x] Manual verification in browser, horizontal layout: last section shrinks to label width when labels are short; other sections expand.
- [x] Labels overflow into inter-box spacers (both axes) and up to the card padding, matching prior behaviour.
- [x] Verify in production-like HA dashboard with several different configs (auto, vertical, horizontal; multi-section; long entity names).