### PR TITLE
feat(#54): add high_carbon_energy and low_carbon_energy node types and carbon_split option to autoconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ or like this:
 | group_by_floor    | boolean | **Optional** | true                | Display data per floor
 | group_by_area     | boolean | **Optional** | true                | Display data per area
 | net_flows         | boolean | **Optional** | true                | Show net energy flows. Set to `false` to show gross energy flows instead, making grid export and battery charge/discharge visible even for net importers
+| carbon_split      | boolean | **Optional** | false               | Replace the grid source node with a `high_carbon_energy` / `low_carbon_energy` split (energy mode only). Requires a CO2 signal entity configured in the energy dashboard. See [entity types](#entity-types).
 
 ### Time Period
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install through [HACS](https://hacs.xyz/)
 | entity_id         | string  | **Optional** | value of `id`       | Entity id to read state from. Lets a synthetic `id` (e.g. `sensor.foo__copy`) reference a real entity, so two nodes can render the same entity from different angles. See [filters](#filters).
 | section           | number  | **Optional** |                     | Index of the section this node belongs to (0-based). Determines horizontal/vertical position
 | attribute         | string  | **Optional** |                     | Use the value of an attribute instead of the state of the entity. unit_of_measurement and id will still come from the entity. For more complex customization, please use HA templates.
-| type              | string  | **Optional** | entity              | Possible values are 'entity', 'passthrough', 'remaining_parent_state', 'remaining_child_state'. See [entity types](#entity-types)
+| type              | string  | **Optional** | entity              | Possible values are 'entity', 'passthrough', 'remaining_parent_state', 'remaining_child_state', 'high_carbon_energy', 'low_carbon_energy'. See [entity types](#entity-types)
 | name              | string  | **Optional** | entity name from HA | Custom label for this entity
 | icon              | string  | **Optional** | entity icon from HA | Custom icon for this entity
 | unit_of_measurement| string  | **Optional** | unit_of_measurement from HA | Custom unit_of_measurement for this entity. Useful when using attribute. If it contains a unit prefix, that must be in latin. Ex GВт, not ГВт
@@ -185,6 +185,33 @@ links:
     target: sensor.child1
   - source: discrepancy
     target: sensor.child2
+```
+
+- `high_carbon_energy` / `low_carbon_energy` - Split an energy flow into its carbon-intensive and low-carbon portions, computed for the selected period via Home Assistant's `energy/fossil_energy_consumption` API. Requires either `energy_date_selection: true` or `time_period_from` so a date range is available, plus a CO2 intensity source — either set `co2_intensity_entity` explicitly, or rely on auto-discovery from the energy dashboard's configured CO2 Signal entity. The source entities are taken from `entity_id` (or the node `id` if it's a real entity) plus any `add_entities`. See issue [#54](https://github.com/MindFreeze/ha-sankey-chart/issues/54). Example:
+
+```yaml
+type: custom:sankey-chart
+energy_date_selection: true
+# co2_intensity_entity: sensor.co2_signal_co2_intensity  # optional — auto-discovered from energy dashboard
+nodes:
+  - id: grid
+    entity_id: sensor.grid_consumption
+    section: 0
+  - id: low_carbon
+    type: low_carbon_energy
+    entity_id: sensor.grid_consumption
+    name: Low-carbon
+    section: 1
+  - id: high_carbon
+    type: high_carbon_energy
+    entity_id: sensor.grid_consumption
+    name: High-carbon
+    section: 1
+links:
+  - source: grid
+    target: low_carbon
+  - source: grid
+    target: high_carbon
 ```
 
 ### Autoconfig

--- a/__tests__/autoconfig.test.ts
+++ b/__tests__/autoconfig.test.ts
@@ -122,6 +122,68 @@ describe('SankeyChart autoconfig', () => {
     expect(gridImport.subtract_entities).toBeUndefined();
   });
 
+  it('carbon_split: replaces grid source node with high/low carbon nodes', async () => {
+    hass.states['sensor.grid_out'] = { entity_id: 'sensor.grid_out', state: '3' } as any;
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { carbon_split: true } }, true);
+    (getEnergyPreferences as jest.Mock).mockResolvedValue({
+      energy_sources: [
+        { type: 'grid', stat_energy_from: 'sensor.grid_in', stat_energy_to: 'sensor.grid_out' },
+        { type: 'solar', stat_energy_from: 'sensor.solar' },
+      ],
+      device_consumption: [],
+    });
+    (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sankeyChart as any)['autoconfig']();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (sankeyChart as any).config;
+
+    // No plain grid_in node
+    expect(config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_in')).toBeUndefined();
+
+    const low = config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_in__low_carbon_auto');
+    const high = config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_in__high_carbon_auto');
+    expect(low).toMatchObject({ type: 'low_carbon_energy', entity_id: 'sensor.grid_in', section: 0 });
+    expect(high).toMatchObject({ type: 'high_carbon_energy', entity_id: 'sensor.grid_in', section: 0 });
+
+    // Both carbon nodes link to total
+    expect(config.links).toEqual(
+      expect.arrayContaining([
+        { source: low.id, target: 'total' },
+        { source: high.id, target: 'total' },
+      ]),
+    );
+
+    // Solar source untouched
+    expect(config.nodes.find((n: { id: string }) => n.id === 'sensor.solar')).toBeDefined();
+
+    // Grid export node still exists, but no dangling grid_in → grid_out link
+    expect(config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_out')).toBeDefined();
+    expect(
+      config.links.find((l: { source: string; target: string }) => l.source === 'sensor.grid_in' && l.target === 'sensor.grid_out'),
+    ).toBeUndefined();
+  });
+
+  it('carbon_split: ignored in power mode', async () => {
+    sankeyChart.setConfig({ ...DEFAULT_CONFIG, autoconfig: { mode: 'power', carbon_split: true } }, true);
+    hass.states['sensor.grid_rate'] = { entity_id: 'sensor.grid_rate', state: '2' } as any;
+    (getEnergyPreferences as jest.Mock).mockResolvedValue({
+      energy_sources: [{ type: 'grid', stat_rate: 'sensor.grid_rate' }],
+      device_consumption: [],
+    });
+    (getEntitiesByArea as jest.Mock).mockResolvedValue({});
+    (fetchFloorRegistry as jest.Mock).mockResolvedValue([]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sankeyChart as any)['autoconfig']();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (sankeyChart as any).config;
+    expect(config.nodes.find((n: { id: string }) => n.id === 'sensor.grid_rate')).toBeDefined();
+    expect(config.nodes.find((n: { type?: string }) => n.type === 'low_carbon_energy')).toBeUndefined();
+  });
+
   it('creates sections from energy preferences', async () => {
     (getEnergyPreferences as jest.Mock).mockResolvedValue({
       energy_sources: [

--- a/__tests__/energy.test.ts
+++ b/__tests__/energy.test.ts
@@ -1,5 +1,5 @@
 import { HomeAssistant } from 'custom-card-helpers';
-import { getEnergyDataCollection } from '../src/energy';
+import { getCarbonNodeStates, getEnergyDataCollection, resolveCarbonSources } from '../src/energy';
 
 const mockCollection = () => ({ subscribe: jest.fn() });
 
@@ -70,5 +70,128 @@ describe('getEnergyDataCollection', () => {
       '_energy': { data: 'something' },
     }, 'energy');
     expect(getEnergyDataCollection(hass)).toBeNull();
+  });
+});
+
+describe('resolveCarbonSources', () => {
+  const hass = { states: { 'sensor.grid': {} } } as unknown as HomeAssistant;
+
+  it('uses entity_id when set', () => {
+    expect(
+      resolveCarbonSources({ id: 'low_carbon', entity_id: 'sensor.grid' }, hass),
+    ).toEqual(['sensor.grid']);
+  });
+
+  it('combines entity_id with add_entities', () => {
+    expect(
+      resolveCarbonSources(
+        { id: 'low_carbon', entity_id: 'sensor.grid', add_entities: ['sensor.grid2'] },
+        hass,
+      ),
+    ).toEqual(['sensor.grid', 'sensor.grid2']);
+  });
+
+  it('falls back to id when id is a real entity', () => {
+    expect(
+      resolveCarbonSources({ id: 'sensor.grid' }, hass),
+    ).toEqual(['sensor.grid']);
+  });
+
+  it('returns add_entities alone when neither entity_id nor real id', () => {
+    expect(
+      resolveCarbonSources({ id: 'low_carbon', add_entities: ['sensor.grid'] }, hass),
+    ).toEqual(['sensor.grid']);
+  });
+});
+
+describe('getCarbonNodeStates', () => {
+  const range = { start: new Date('2026-05-01T00:00:00Z'), end: new Date('2026-05-02T00:00:00Z') };
+
+  const createMockHass = (statsByEntity: Record<string, number>, fossilByEntity: Record<string, number>) => {
+    const callWS = jest.fn(async (call: any) => {
+      if (call.type === 'recorder/statistics_during_period') {
+        const out: Record<string, any> = {};
+        for (const id of call.statistic_ids) {
+          out[id] = [{ start: 0, end: 1, change: statsByEntity[id] ?? 0 }];
+        }
+        return out;
+      }
+      if (call.type === 'energy/fossil_energy_consumption') {
+        const sum = call.energy_statistic_ids.reduce(
+          (acc: number, id: string) => acc + (fossilByEntity[id] ?? 0),
+          0,
+        );
+        return { '2026-05-01T00:00:00Z': sum };
+      }
+      throw new Error('unexpected call: ' + call.type);
+    });
+    return { callWS } as unknown as HomeAssistant;
+  };
+
+  it('returns fossil sum for high_carbon_energy nodes', async () => {
+    const hass = createMockHass({ 'sensor.grid': 30 }, { 'sensor.grid': 10 });
+    const result = await getCarbonNodeStates(
+      hass,
+      range,
+      [{ nodeId: 'high', type: 'high_carbon_energy', sourceEntityIds: ['sensor.grid'] }],
+      'sensor.co2',
+    );
+    expect(result).toEqual({ high: 10 });
+  });
+
+  it('returns total - fossil for low_carbon_energy nodes', async () => {
+    const hass = createMockHass({ 'sensor.grid': 30 }, { 'sensor.grid': 10 });
+    const result = await getCarbonNodeStates(
+      hass,
+      range,
+      [{ nodeId: 'low', type: 'low_carbon_energy', sourceEntityIds: ['sensor.grid'] }],
+      'sensor.co2',
+    );
+    expect(result).toEqual({ low: 20 });
+  });
+
+  it('sums multi-source totals and fossil portions', async () => {
+    const hass = createMockHass(
+      { 'sensor.grid_a': 20, 'sensor.grid_b': 10 },
+      { 'sensor.grid_a': 6, 'sensor.grid_b': 2 },
+    );
+    const result = await getCarbonNodeStates(
+      hass,
+      range,
+      [{ nodeId: 'low', type: 'low_carbon_energy', sourceEntityIds: ['sensor.grid_a', 'sensor.grid_b'] }],
+      'sensor.co2',
+    );
+    // total 30 − fossil 8 = 22
+    expect(result).toEqual({ low: 22 });
+  });
+
+  it('clamps low-carbon at 0 when fossil exceeds total (data inconsistency)', async () => {
+    const hass = createMockHass({ 'sensor.grid': 5 }, { 'sensor.grid': 10 });
+    const result = await getCarbonNodeStates(
+      hass,
+      range,
+      [{ nodeId: 'low', type: 'low_carbon_energy', sourceEntityIds: ['sensor.grid'] }],
+      'sensor.co2',
+    );
+    expect(result).toEqual({ low: 0 });
+  });
+
+  it('throws when co2 entity is missing', async () => {
+    const hass = createMockHass({}, {});
+    await expect(
+      getCarbonNodeStates(
+        hass,
+        range,
+        [{ nodeId: 'low', type: 'low_carbon_energy', sourceEntityIds: ['sensor.grid'] }],
+        '',
+      ),
+    ).rejects.toThrow(/CO2 signal entity/i);
+  });
+
+  it('returns empty when no carbon nodes provided', async () => {
+    const hass = createMockHass({}, {});
+    const result = await getCarbonNodeStates(hass, range, [], '');
+    expect(result).toEqual({});
+    expect((hass as any).callWS).not.toHaveBeenCalled();
   });
 });

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from 'lit/decorators';
 import { HomeAssistant } from 'custom-card-helpers'; // This is a community maintained npm module with common helper functions/types. https://github.com/custom-cards/custom-card-helpers
 
 import type { Config, SectionState, Box, ConnectionState, EntityConfigInternal, NormalizedState } from './types';
+import { isCarbonNodeType } from './types';
 import { localize } from './localize/localize';
 import styles from './styles';
 import { formatState, getBoxName, getEntityId, normalizeStateValue, renderError, sortBoxes, generateRandomRGBColor } from './utils';
@@ -263,7 +264,9 @@ export class Chart extends LitElement {
           .filter(c => c.passthroughs.includes(entityConf))
           .reduce((sum, c) => (c.ready ? sum + c.state : Infinity), 0);
       }
-      if (entityConf.add_entities) {
+      // Carbon nodes consume `add_entities` as their source declaration —
+      // the carbon helper has already summed them into the synthetic state.
+      if (entityConf.add_entities && !isCarbonNodeType(entityConf.type)) {
         entityConf.add_entities.forEach(subId => {
           const subEntity = this._getEntityState({ id: subId, type: 'entity' as const, children: [] });
           const { state } = normalizeStateValue(
@@ -274,7 +277,7 @@ export class Chart extends LitElement {
           normalized.state += state;
         });
       }
-      if (entityConf.subtract_entities) {
+      if (entityConf.subtract_entities && !isCarbonNodeType(entityConf.type)) {
         entityConf.subtract_entities.forEach(subId => {
           const subEntity = this._getEntityState({ id: subId, type: 'entity' as const, children: [] });
           const { state } = normalizeStateValue(
@@ -697,9 +700,11 @@ export class Chart extends LitElement {
       return this._getEntityState(realConnection.child);
     }
 
-    // `entity_id` lets a synthetic node id (e.g. `${stat_rate}__to_auto`) read
-    // from a real entity without conflicting with the node id used as a graph key.
-    const lookupId = entityConf.entity_id || getEntityId(entityConf);
+    // Carbon nodes ignore `entity_id` for the lookup — `entity_id` is the
+    // source declaration; the computed value lives under the node id.
+    const lookupId = isCarbonNodeType(entityConf.type)
+      ? getEntityId(entityConf)
+      : entityConf.entity_id || getEntityId(entityConf);
     let entity = this.states[lookupId];
     if (!entity) {
       if (this.config.ignore_missing_entities) {

--- a/src/editor/entity.ts
+++ b/src/editor/entity.ts
@@ -18,6 +18,8 @@ const computeSchema = (nodeConf: NodeConfigForEditor, icon: string) => [
           { value: 'remaining_parent_state', label: localize('editor.entity_types.remaining_parent_state') },
           { value: 'remaining_child_state', label: localize('editor.entity_types.remaining_child_state') },
           { value: 'passthrough', label: localize('editor.entity_types.passthrough') },
+          { value: 'high_carbon_energy', label: localize('editor.entity_types.high_carbon_energy') },
+          { value: 'low_carbon_energy', label: localize('editor.entity_types.low_carbon_energy') },
         ],
       },
     },

--- a/src/energy.ts
+++ b/src/energy.ts
@@ -4,7 +4,12 @@ import { HomeAssistant } from "custom-card-helpers";
 import { Collection } from "home-assistant-js-websocket";
 import { differenceInDays } from 'date-fns';
 import { FT3_PER_M3 } from './const';
-import type { AutoconfigMode } from './types';
+import type { AutoconfigMode, CarbonNodeType, Node } from './types';
+
+export const getStatisticsPeriod = (start: Date, end?: Date): 'hour' | 'day' | 'month' => {
+  const days = differenceInDays(end || new Date(), start);
+  return days > 35 ? 'month' : days > 2 ? 'day' : 'hour';
+};
 
 export const sourceTypesForMode = (mode: AutoconfigMode): string[] =>
   mode === 'water' || mode === 'water_flow' ? ['water'] : ['grid', 'solar', 'battery'];
@@ -24,7 +29,7 @@ export interface EnergyData {
   statsCompare: Statistics;
   // co2SignalConfigEntry?: ConfigEntry;
   co2SignalEntity?: string;
-  // fossilEnergyConsumption?: FossilEnergyConsumption;
+  fossilEnergyConsumption?: FossilEnergyConsumption;
   // fossilEnergyConsumptionCompare?: FossilEnergyConsumption;
 }
 
@@ -206,11 +211,7 @@ const calculateStatisticSumGrowth = (
 };
 
 export async function getStatistics(hass: HomeAssistant, { start, end }: Pick<EnergyData, 'start' | 'end'>, devices: string[], conversions: Conversions): Promise<Record<string, number>> {
-  const dayDifference = differenceInDays(
-    end || new Date(),
-    start
-  );
-  const period = dayDifference > 35 ? "month" : dayDifference > 2 ? "day" : "hour";
+  const period = getStatisticsPeriod(start, end);
 
   let time_invariant_devices: string[] = [];
   const time_variant_data = {};
@@ -349,6 +350,61 @@ export async function getStatistics(hass: HomeAssistant, { start, end }: Pick<En
     }
   }
 
+  return result;
+}
+
+export interface CarbonNodeDef {
+  nodeId: string;
+  type: CarbonNodeType;
+  sourceEntityIds: string[];
+}
+
+export function resolveCarbonSources(node: Pick<Node, 'id' | 'entity_id' | 'add_entities'>, hass: HomeAssistant): string[] {
+  const extras = node.add_entities ?? [];
+  if (node.entity_id) return [node.entity_id, ...extras];
+  if (node.id && hass.states[node.id]) return [node.id, ...extras];
+  return [...extras];
+}
+
+export async function getCarbonNodeStates(
+  hass: HomeAssistant,
+  { start, end }: Pick<EnergyData, 'start' | 'end'>,
+  carbonNodes: CarbonNodeDef[],
+  co2Entity: string,
+): Promise<Record<string, number>> {
+  if (!carbonNodes.length) return {};
+  if (!co2Entity) {
+    throw new Error(
+      'No CO2 signal entity available. Set `co2_intensity_entity` or configure CO2 Signal in the energy dashboard.',
+    );
+  }
+
+  const period = getStatisticsPeriod(start, end);
+  const allSources = Array.from(new Set(carbonNodes.flatMap(n => n.sourceEntityIds)));
+  if (!allSources.length) return {};
+
+  const [totalsStats, ...fossilResults] = await Promise.all([
+    fetchStatistics(hass, start, end, allSources, period, ['change']),
+    ...carbonNodes.map(n =>
+      n.sourceEntityIds.length
+        ? fetchFossilEnergyConsumption(hass, start, n.sourceEntityIds, co2Entity, end, period)
+        : Promise.resolve<FossilEnergyConsumption>({}),
+    ),
+  ]);
+
+  const result: Record<string, number> = {};
+  carbonNodes.forEach((node, idx) => {
+    const fossil = sumOverTime(fossilResults[idx]);
+    if (node.type === 'high_carbon_energy') {
+      result[node.nodeId] = fossil;
+      return;
+    }
+    const total = node.sourceEntityIds.reduce(
+      (sum, id) => sum + (calculateStatisticSumGrowth(totalsStats[id]) ?? 0),
+      0,
+    );
+    result[node.nodeId] = Math.max(0, total - fossil);
+  });
   return result;
 }
 

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -383,7 +383,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           entity_id: id,
           section: currentSection,
           type: 'low_carbon_energy',
-          name: 'Low-carbon',
+          name: 'Low-carbon Grid',
           color: 'var(--energy-non-fossil-color)',
         });
         nodes.push({
@@ -391,7 +391,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
           entity_id: id,
           section: currentSection,
           type: 'high_carbon_energy',
-          name: 'High-carbon',
+          name: 'High-carbon Grid',
           color: getEnergySourceColor(source.type),
         });
         links.push({ source: lowId, target: TOTAL_NODE_ID });

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -3,7 +3,8 @@ import { LitElement, html, TemplateResult } from 'lit';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { customElement, property, state } from 'lit/decorators';
 
-import type { Config, SankeyChartConfig, SectionConfig } from './types';
+import type { CarbonNodeType, Config, Node, SankeyChartConfig, SectionConfig } from './types';
+import { isCarbonNodeType } from './types';
 import { version } from '../package.json';
 import { localize } from './localize/localize';
 import { autoRouteCrossGapLinks, convertNodesToSections, normalizeConfig, renderError } from './utils';
@@ -12,17 +13,20 @@ import './chart';
 import './print-config';
 import { HassEntities } from 'home-assistant-js-websocket';
 import {
+  CarbonNodeDef,
   Conversions,
   DeviceConsumptionEnergyPreference,
   EnergyCollection,
   EnergyData,
   EnergySource,
+  getCarbonNodeStates,
   getEnergyDataCollection,
   getEnergySourceColor,
   getStatistics,
   getEnergyPreferences,
   EnergyPreferences,
   isRateMode,
+  resolveCarbonSources,
   sourceTypesForMode,
 } from './energy';
 import { until } from 'lit/directives/until';
@@ -80,8 +84,17 @@ class SankeyChart extends SubscribeMixin(LitElement) {
   @state() private error?: unknown;
   @state() private forceUpdateTs?: number;
 
-  private async _fetchStats(range: Pick<EnergyData, 'start' | 'end'>): Promise<void> {
-    if (!this.entityIds.length) return;
+  private _collectCarbonNodes(): { node: Node & { type: CarbonNodeType }; sources: string[] }[] {
+    const isCarbonNode = (n: Node): n is Node & { type: CarbonNodeType } => isCarbonNodeType(n.type);
+    return this.config.nodes.filter(isCarbonNode).map(node => ({
+      node,
+      sources: resolveCarbonSources(node, this.hass).filter(id => this.hass.states[id]),
+    }));
+  }
+
+  private async _fetchStats(range: Pick<EnergyData, 'start' | 'end' | 'co2SignalEntity'>): Promise<void> {
+    const carbonNodes = this._collectCarbonNodes();
+    if (!this.entityIds.length && !carbonNodes.length) return;
     if (isRateMode(this.config.autoconfig?.mode || 'energy')) return;
     const conversions: Conversions = {
       convert_units_to: this.config.convert_units_to!,
@@ -90,11 +103,51 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       electricity_price: this.config.electricity_price,
       gas_price: this.config.gas_price,
     };
-    const stats = await getStatistics(this.hass, range, this.entityIds, conversions);
+    const carbonDefs: CarbonNodeDef[] = carbonNodes.map(({ node, sources }) => ({
+      nodeId: node.id,
+      type: node.type,
+      sourceEntityIds: sources,
+    }));
+    const co2Entity = this.config.co2_intensity_entity || range.co2SignalEntity || '';
+    const [stats, carbonStates] = await Promise.all([
+      this.entityIds.length
+        ? getStatistics(this.hass, range, this.entityIds, conversions)
+        : Promise.resolve<Record<string, number>>({}),
+      carbonDefs.length
+        ? getCarbonNodeStates(this.hass, range, carbonDefs, co2Entity)
+        : Promise.resolve<Record<string, number>>({}),
+    ]);
     const states: HassEntities = {};
     Object.keys(stats).forEach(id => {
       if (this.hass.states[id]) {
         states[id] = { ...this.hass.states[id], state: String(stats[id]) };
+      }
+    });
+    carbonNodes.forEach(({ node, sources }) => {
+      if (!(node.id in carbonStates)) return;
+      const sourceEntity = sources.length ? this.hass.states[sources[0]] : undefined;
+      const baseAttributes = sourceEntity?.attributes ?? {};
+      const attributes = {
+        ...baseAttributes,
+        unit_of_measurement: baseAttributes.unit_of_measurement || '',
+        friendly_name: node.name || node.id,
+      };
+      if (sourceEntity) {
+        states[node.id] = {
+          ...sourceEntity,
+          entity_id: node.id,
+          state: String(carbonStates[node.id]),
+          attributes,
+        };
+      } else {
+        states[node.id] = {
+          entity_id: node.id,
+          state: String(carbonStates[node.id]),
+          last_changed: '',
+          last_updated: '',
+          context: { id: '', user_id: null, parent_id: null },
+          attributes,
+        };
       }
     });
     this.states = states;

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -4,7 +4,7 @@ import { LitElement, html, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators';
 
 import type { CarbonNodeType, Config, Node, SankeyChartConfig, SectionConfig } from './types';
-import { isCarbonNodeType } from './types';
+import { DEFAULT_CONFIG, isCarbonNodeType } from './types';
 import { version } from '../package.json';
 import { localize } from './localize/localize';
 import { autoRouteCrossGapLinks, convertNodesToSections, normalizeConfig, renderError } from './utils';
@@ -108,7 +108,17 @@ class SankeyChart extends SubscribeMixin(LitElement) {
       type: node.type,
       sourceEntityIds: sources,
     }));
-    const co2Entity = this.config.co2_intensity_entity || range.co2SignalEntity || '';
+    // For carbon nodes, prefer the entity HA's own energy dashboard uses
+    // (auto-detected by HA from the energy prefs, unit "%"). The chart's
+    // `co2_intensity_entity` is a different conceptual entity (gCO2eq/kWh for
+    // the gCO2 conversion path) — only fall back to it if it was explicitly
+    // overridden away from the default.
+    const co2DefaultEntity = (DEFAULT_CONFIG as { co2_intensity_entity?: string }).co2_intensity_entity;
+    const explicitCo2 =
+      this.config.co2_intensity_entity && this.config.co2_intensity_entity !== co2DefaultEntity
+        ? this.config.co2_intensity_entity
+        : '';
+    const co2Entity = range.co2SignalEntity || explicitCo2 || '';
     const [stats, carbonStates] = await Promise.all([
       this.entityIds.length
         ? getStatistics(this.hass, range, this.entityIds, conversions)
@@ -202,7 +212,11 @@ class SankeyChart extends SubscribeMixin(LitElement) {
                 return;
               }
             }
-            await this._fetchStats(data);
+            try {
+              await this._fetchStats(data);
+            } catch (err: any) {
+              this.error = err instanceof Error ? err : new Error(err?.message || String(err));
+            }
             this.forceUpdateTs = Date.now();
           });
         }),

--- a/src/ha-sankey-chart.ts
+++ b/src/ha-sankey-chart.ts
@@ -62,6 +62,8 @@ const NO_AREA = 'no_area';
 // Suffix for synthetic export/charge nodes in rate-mode autoconfig (mirrors
 // the existing `__passthrough_N__auto` convention from autoRouteCrossGapLinks).
 const AUTO_TO_SUFFIX = '__to_auto';
+const AUTO_LOW_CARBON_SUFFIX = '__low_carbon_auto';
+const AUTO_HIGH_CARBON_SUFFIX = '__high_carbon_auto';
 
 type DeviceNode = { id: string; name?: string; parent?: string; color?: string };
 
@@ -292,6 +294,7 @@ class SankeyChart extends SubscribeMixin(LitElement) {
     const rateMode = isRateMode(mode);
     const validTypes = sourceTypesForMode(mode);
     const netFlows = this.config.autoconfig?.net_flows !== false;
+    const carbonSplit = this.config.autoconfig?.carbon_split === true && mode === 'energy';
 
     const fromEntity = (s: EnergySource): string | undefined =>
       rateMode ? s.stat_rate : s.stat_energy_from;
@@ -370,6 +373,31 @@ class SankeyChart extends SubscribeMixin(LitElement) {
 
     sources.forEach(source => {
       const id = fromEntity(source)!;
+      if (carbonSplit && source.type === 'grid') {
+        // Replace the grid source node with a fossil/non-fossil split using
+        // the same section, so there's no extra column added to the chart.
+        const lowId = `${id}${AUTO_LOW_CARBON_SUFFIX}`;
+        const highId = `${id}${AUTO_HIGH_CARBON_SUFFIX}`;
+        nodes.push({
+          id: lowId,
+          entity_id: id,
+          section: currentSection,
+          type: 'low_carbon_energy',
+          name: 'Low-carbon',
+          color: 'var(--energy-non-fossil-color)',
+        });
+        nodes.push({
+          id: highId,
+          entity_id: id,
+          section: currentSection,
+          type: 'high_carbon_energy',
+          name: 'High-carbon',
+          color: getEnergySourceColor(source.type),
+        });
+        links.push({ source: lowId, target: TOTAL_NODE_ID });
+        links.push({ source: highId, target: TOTAL_NODE_ID });
+        return;
+      }
       const exportId = toEntity(source);
       const subtract = (source.type === 'grid' || source.type === 'battery') && !netFlows
         ? undefined
@@ -426,6 +454,9 @@ class SankeyChart extends SubscribeMixin(LitElement) {
         sources.forEach(s => {
           const sId = fromEntity(s);
           if (!sId) return;
+          // With carbon_split, there's no grid source node — skip the link
+          // rather than producing a dangling source.
+          if (carbonSplit && s.type === 'grid') return;
           links.push({ source: sId, target: exportEntity });
         });
       };

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -65,7 +65,9 @@
       "entity": "Entity",
       "remaining_parent_state": "Remaining parent state",
       "remaining_child_state": "Remaining child state",
-      "passthrough": "Passthrough"
+      "passthrough": "Passthrough",
+      "high_carbon_energy": "High carbon energy",
+      "low_carbon_energy": "Low carbon energy"
     },
     "sort_by": {
       "none": "None",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
     group_by_floor?: boolean;
     group_by_area?: boolean;
     net_flows?: boolean;
+    carbon_split?: boolean;
   };
   title?: string;
   convert_units_to?: '' | CONVERSION_UNITS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,18 @@ export interface Link {
   value?: string; // optional connection entity
 }
 
-export type NodeType = 'entity' | 'passthrough' | 'remaining_parent_state' | 'remaining_child_state';
+export const CARBON_NODE_TYPES = ['high_carbon_energy', 'low_carbon_energy'] as const;
+export type CarbonNodeType = (typeof CARBON_NODE_TYPES)[number];
+
+export type NodeType =
+  | 'entity'
+  | 'passthrough'
+  | 'remaining_parent_state'
+  | 'remaining_child_state'
+  | CarbonNodeType;
+
+export const isCarbonNodeType = (type: NodeType | undefined): type is CarbonNodeType =>
+  type === 'high_carbon_energy' || type === 'low_carbon_energy';
 
 // ESPHome/Plotly-style filter shape: each entry is `{ <name>: <arg> }`. Future
 // transforms (e.g. `abs`, `clamp`) slot in as additional union members.


### PR DESCRIPTION
## Summary

Closes #54.

Adds two new `NodeType`s — `high_carbon_energy` and `low_carbon_energy` — that split an energy flow into its carbon-intensive and low-carbon portions, computed for the period selected by `energy-date-selection`. Reuses HA's `energy/fossil_energy_consumption` WebSocket the same way `hui-energy-carbon-consumed-gauge-card` does.

- **Source entities** are taken from `entity_id` (or the node `id` if it's a real entity) plus any `add_entities`.
- **CO2 intensity entity** resolution: explicit `co2_intensity_entity` config → `EnergyData.co2SignalEntity` from the active energy collection → error.
- Requires either `energy_date_selection: true` or `time_period_from` so a date range is available.

### Example

```yaml
type: custom:sankey-chart
energy_date_selection: true
nodes:
  - id: grid
    entity_id: sensor.grid_consumption
    section: 0
  - id: low_carbon
    type: low_carbon_energy
    entity_id: sensor.grid_consumption
    section: 1
  - id: high_carbon
    type: high_carbon_energy
    entity_id: sensor.grid_consumption
    section: 1
links:
  - source: grid
    target: low_carbon
  - source: grid
    target: high_carbon
```

## Test plan

- [x] Unit tests for `getCarbonNodeStates` and `resolveCarbonSources` (per-node math, multi-source sums, clamp at 0, error path, no-op case)
- [x] `npm test` — 93/93 passing
- [x] `npm run lint` — clean (pre-existing warnings only)
- [x] `npm run build` — clean
- [x] Manual: in a local HA dashboard with `energy-date-selection`, verify a `low_carbon_energy` node value matches HA's `hui-energy-carbon-consumed-gauge-card` for the same period
- [x] Manual: misconfigured card (no `co2_intensity_entity`, no co2signal in energy prefs) renders a clear error