### PR TITLE
feat(#366): add box_thickness and connection_margin config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Install through [HACS](https://hacs.xyz/)
 | show_states       | boolean | true                | Display entity states
 | show_units        | boolean | true                | Display unit of measurement
 | min_box_size      | number  | 3                   | Minimum size of an entity box
-| min_box_distance  | number  | 5                   | Minimum space between entity boxes
+| min_box_distance  | number  | 5                   | Minimum space between entity boxes in the same section (perpendicular to flow)
+| box_thickness     | number  | 15                  | Thickness in px of the colored bar on each entity box (its width in horizontal layout, height in vertical)
+| connection_margin | number  | 0                   | Gap in px between a box and where its connection curves start/end (along the direction of flow). Increase to separate the curves from the box bars
 | min_state         | number  | >0                  | Any entity below this value will not be displayed. Only positive numbers above 0 are allowed. The default is to show everything above 0.
 | throttle          | number  |                     | Minimum time in ms between updates/rerenders
 | static_scale      | number  |                     | State value corresponding to the maximum size (height for horizontal layout and width in vertical) of the card. For example, if this is set to 1000, then a box with state 500 will take up half of its section. If some section exceeds the value of `static_scale`, the card will dynamically rescale overriding this option. See [#153](https://github.com/MindFreeze/ha-sankey-chart/issues/153).

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -89,6 +89,69 @@ describe('SankeyChart', () => {
 
     expect(sankeyChartBase.shadowRoot?.innerHTML.replace(/<!--.*-->/g, '')).toMatchSnapshot();
   });
+
+  it('honors box_thickness and connection_margin in rendered SVG', async () => {
+    const config: SankeyChartConfig = {
+      type: '',
+      box_thickness: 5,
+      connection_margin: 8,
+      nodes: [
+        { id: 'ent1', section: 0, type: 'entity', name: '' },
+        { id: 'ent2', section: 1, type: 'entity', name: '' },
+      ],
+      links: [{ source: 'ent1', target: 'ent2' }],
+      sections: [{}, {}],
+    };
+    sankeyChart.setConfig(config, true);
+    document.body.appendChild(sankeyChart);
+    await sankeyChart.updateComplete;
+    const base = sankeyChart.shadowRoot?.querySelector('sankey-chart-base') as LitElement;
+    await base.updateComplete;
+
+    // First color bar: width should match box_thickness (5px), not the 15px default.
+    const colorBars = base.shadowRoot?.querySelectorAll('rect.color-bar');
+    expect(colorBars && colorBars.length).toBe(2);
+    expect(colorBars![0].getAttribute('width')).toBe('5');
+    // Second section's color bar sits at the right edge — its x marks the end
+    // of section 0, which is where farEdge is measured against.
+    const nextSectionX = Number(colorBars![1].getAttribute('x'));
+
+    // Connector path: nearEdge = box_thickness + connection_margin = 13;
+    // farEdge = nextSectionX - connection_margin.
+    const path = base.shadowRoot?.querySelector('g.connectors path');
+    const d = path?.getAttribute('d') || '';
+    const moveTo = d.match(/^M([\d.]+),/);
+    expect(moveTo).not.toBeNull();
+    expect(Number(moveTo![1])).toBe(13);
+    const lineTo = d.match(/L([\d.]+),/);
+    expect(lineTo).not.toBeNull();
+    expect(Number(lineTo![1])).toBe(nextSectionX - 8);
+  });
+
+  it('collapses the color bar when box_thickness is 0', async () => {
+    const config: SankeyChartConfig = {
+      type: '',
+      box_thickness: 0,
+      nodes: [
+        { id: 'ent1', section: 0, type: 'entity', name: '' },
+        { id: 'ent2', section: 1, type: 'entity', name: '' },
+      ],
+      links: [{ source: 'ent1', target: 'ent2' }],
+      sections: [{}, {}],
+    };
+    sankeyChart.setConfig(config, true);
+    document.body.appendChild(sankeyChart);
+    await sankeyChart.updateComplete;
+    const base = sankeyChart.shadowRoot?.querySelector('sankey-chart-base') as LitElement;
+    await base.updateComplete;
+
+    const colorBar = base.shadowRoot?.querySelector('rect.color-bar');
+    expect(colorBar?.getAttribute('width')).toBe('0');
+    // With default connection_margin (0), the connector starts at the box's
+    // right edge — which, with thickness 0, is the section's left edge (x=0).
+    const path = base.shadowRoot?.querySelector('g.connectors path');
+    expect(path?.getAttribute('d')).toMatch(/^M0,/);
+  });
 });
 
 describe('Missing entities', () => {

--- a/__tests__/zoom.test.ts
+++ b/__tests__/zoom.test.ts
@@ -9,6 +9,8 @@ const config = {
   height: 200,
   min_box_size: 3,
   min_box_distance: 5,
+  box_thickness: 15,
+  connection_margin: 0,
   min_state: 0,
   nodes: [],
   links: [],

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -11,7 +11,6 @@ import { localize } from './localize/localize';
 import styles from './styles';
 import { formatState, getBoxName, getEntityId, normalizeStateValue, renderError, sortBoxes, generateRandomRGBColor } from './utils';
 import {
-  BOX_COLOR_BAR,
   CHAR_WIDTH_RATIO,
   LABEL_PADDING,
   MIN_LABEL_HEIGHT,
@@ -539,12 +538,13 @@ export class Chart extends LitElement {
     }
     const stateLines = show_states ? 1 : 0;
     const totalLines = stateLines + nameLines;
-    if (!totalLines) return BOX_COLOR_BAR;
-    return BOX_COLOR_BAR + 5 + totalLines * MIN_LABEL_HEIGHT;
+    const { box_thickness } = this.config;
+    if (!totalLines) return box_thickness;
+    return box_thickness + 5 + totalLines * MIN_LABEL_HEIGHT;
   }
 
   private _naturalSectionWidth(section: SectionState): number {
-    const { show_states, show_names, show_units, round, monetary_unit } = this.config;
+    const { show_states, show_names, show_units, round, monetary_unit, box_thickness } = this.config;
     let maxWidth = 0;
     for (const box of section.boxes) {
       if (box.config.type === 'passthrough') continue;
@@ -556,7 +556,7 @@ export class Chart extends LitElement {
       const nameW = nameText.length * NAME_CHAR_WIDTH;
       const separatorW = stateText && nameText ? SEPARATOR_WIDTH : 0;
       const labelW = stateW + separatorW + nameW + 2 * LABEL_PADDING;
-      maxWidth = Math.max(maxWidth, BOX_COLOR_BAR + labelW);
+      maxWidth = Math.max(maxWidth, box_thickness + labelW);
     }
     return maxWidth;
   }

--- a/src/const.ts
+++ b/src/const.ts
@@ -14,7 +14,7 @@ export const NAME_CHAR_WIDTH = 6; // proportional/italic name text is narrower
 export const SEPARATOR_WIDTH = 4; // nbsp between state and name
 export const LABEL_PADDING = 10; // .label has padding: 0 10px
 
-export const BOX_COLOR_BAR = 15; // width/height of the colored bar on each box
+export const DEFAULT_BOX_THICKNESS = 15; // default width/height of the colored bar on each box
 
 export const MIN_HORIZONTAL_SECTION_W = 150;
 export const MIN_VERTICAL_SECTION_H = 150;

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -278,6 +278,8 @@ export class SankeyChartEditor extends LitElement implements LovelaceCardEditor 
           { name: 'height', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
           { name: 'min_box_size', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
           { name: 'min_box_distance', selector: { number: { mode: 'box', unit_of_measurement: 'px' } } },
+          { name: 'box_thickness', selector: { number: { mode: 'box', min: 0, unit_of_measurement: 'px' } } },
+          { name: 'connection_margin', selector: { number: { mode: 'box', min: 0, unit_of_measurement: 'px' } } },
         ],
       },
       {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -34,6 +34,8 @@
       "wide": "Wide",
       "min_box_size": "Min box size",
       "min_box_distance": "Min box distance",
+      "box_thickness": "Box thickness",
+      "connection_margin": "Connection margin",
       "min_state": "Min state",
       "static_scale": "Static scale",
       "round": "Round",

--- a/src/section.ts
+++ b/src/section.ts
@@ -6,11 +6,11 @@ import { formatState, getBoxName, getChildConnections, getEntityId, normalizeSta
 import { FrontendLocaleData, stateIcon } from 'custom-card-helpers';
 import { HassEntity } from 'home-assistant-js-websocket';
 import { renderLabel } from './label';
-import { BOX_COLOR_BAR } from './const';
 
 const XHTML_NS = 'http://www.w3.org/1999/xhtml';
 
 export function renderBranchConnectors(props: {
+  config: Config;
   section: SectionState;
   nextSection?: SectionState;
   sectionIndex: number;
@@ -18,8 +18,9 @@ export function renderBranchConnectors(props: {
   vertical: boolean;
 }): SVGTemplateResult[] {
   const { boxes, size, offset } = props.section;
-  const nearEdge = BOX_COLOR_BAR + offset;
-  const farEdge = size + offset;
+  const { box_thickness, connection_margin } = props.config;
+  const nearEdge = box_thickness + connection_margin + offset;
+  const farEdge = size + offset - connection_margin;
   const midEdge = (nearEdge + farEdge) / 2;
   return boxes
     .filter(b => b.children.length > 0)
@@ -81,7 +82,7 @@ export function renderSection(props: {
   onMouseEnter: (config: Box) => void;
   onMouseLeave: () => void;
 }) {
-  const { show_icons } = props.config;
+  const { show_icons, box_thickness } = props.config;
   const { boxes, spacerSize, offset, size } = props.section;
   const hasChildren = props.nextSection && boxes.some(b => b.children.length > 0);
 
@@ -102,11 +103,11 @@ export function renderSection(props: {
         const isHighlighted = props.highlightedEntities.includes(box.config);
 
         const colorRect = props.vertical
-          ? { x: box.top, y: offset, width: box.size, height: BOX_COLOR_BAR }
-          : { x: offset, y: box.top, width: BOX_COLOR_BAR, height: box.size };
+          ? { x: box.top, y: offset, width: box.size, height: box_thickness }
+          : { x: offset, y: box.top, width: box_thickness, height: box.size };
         const labelArea = props.vertical
-          ? { x: box.top, y: offset + BOX_COLOR_BAR, width: box.size, height: size - BOX_COLOR_BAR }
-          : { x: offset + BOX_COLOR_BAR, y: box.top, width: size - BOX_COLOR_BAR, height: box.size };
+          ? { x: box.top, y: offset + box_thickness, width: box.size, height: size - box_thickness }
+          : { x: offset + box_thickness, y: box.top, width: size - box_thickness, height: box.size };
 
         const classes = classMap({
           box: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import {
   LovelaceCardConfig,
 } from 'custom-card-helpers';
 import { HassEntity, HassServiceTarget } from 'home-assistant-js-websocket';
-import { UNIT_PREFIXES, CONVERSION_UNITS, BOX_COLOR_BAR } from './const';
+import { UNIT_PREFIXES, CONVERSION_UNITS, DEFAULT_BOX_THICKNESS } from './const';
 
 export const DEFAULT_CONFIG: Config = {
   type: 'custom:ha-sankey-chart',
@@ -20,7 +20,7 @@ export const DEFAULT_CONFIG: Config = {
   min_state: 0,
   show_states: true,
   show_units: true,
-  box_thickness: BOX_COLOR_BAR,
+  box_thickness: DEFAULT_BOX_THICKNESS,
   connection_margin: 0,
   nodes: [],
   links: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import {
   LovelaceCardConfig,
 } from 'custom-card-helpers';
 import { HassEntity, HassServiceTarget } from 'home-assistant-js-websocket';
-import { UNIT_PREFIXES, CONVERSION_UNITS } from './const';
+import { UNIT_PREFIXES, CONVERSION_UNITS, BOX_COLOR_BAR } from './const';
 
 export const DEFAULT_CONFIG: Config = {
   type: 'custom:ha-sankey-chart',
@@ -20,6 +20,8 @@ export const DEFAULT_CONFIG: Config = {
   min_state: 0,
   show_states: true,
   show_units: true,
+  box_thickness: BOX_COLOR_BAR,
+  connection_margin: 0,
   nodes: [],
   links: [],
   sections: [],
@@ -59,6 +61,8 @@ export interface SankeyChartConfig extends LovelaceCardConfig {
   energy_collection_key?: string;
   min_box_size?: number;
   min_box_distance?: number;
+  box_thickness?: number;
+  connection_margin?: number;
   throttle?: number;
   min_state?: number;
   static_scale?: number;
@@ -201,6 +205,8 @@ export interface Config extends SankeyChartConfig {
   height: number;
   min_box_size: number;
   min_box_distance: number;
+  box_thickness: number;
+  connection_margin: number;
   min_state: number;
   nodes: Node[];
   links: Link[];


### PR DESCRIPTION
Lets users tune the v6 chart's visual density: shrink the colored box
bar and add breathing room between boxes and the curves running between
them, replacing custom CSS workarounds from v5.