### PR TITLE
ci: modernize build workflow for use as a required check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,20 @@ name: 'Build'
 
 on:
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:
     name: Test build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm test
       - name: Build
-        run: |
-          npm ci
-          npm test
-          npm run build
+        run: npm run build


### PR DESCRIPTION
- Run on PRs to any base branch (was master-only) so PRs to v4 and
  future dev branches also trigger CI
- Update actions/checkout v1 -> v4
- Pin Node 20 via actions/setup-node with npm cache
- Split install/test/build into separate steps for clearer failures