### PR TITLE
fix(#370): allow modifiers after rounding in time_period_from/to

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,11 @@ Examples:
 - `now/M`: Start of the current month
 - `now/y`: Start of the current year
 - `now-1d/d`: Start of the previous day
+- `now/d+7h`: Today at 07:00
+- `now-1d/d+23h`: Yesterday at 23:00
+- `now/d-1h`: Yesterday at 23:00 (equivalent)
+
+Modifiers can be combined: offsets and roundings are applied left-to-right, so anchors like `now/d+7h` (round to today's midnight, then add 7 hours) are supported.
 
 If `time_period_to` is not specified, it defaults to `now`.
 
@@ -282,6 +287,13 @@ type: custom:sankey-chart
 title: Yesterday
 time_period_from: "now-1d/d"
 time_period_to: "now/d"
+```
+
+```yaml
+type: custom:sankey-chart
+title: Quiet hours (23:00–07:00)
+time_period_from: "now-1d/d+23h"
+time_period_to: "now/d+7h"
 ```
 
 

--- a/__tests__/calculateTimePeriod.test.ts
+++ b/__tests__/calculateTimePeriod.test.ts
@@ -1,0 +1,75 @@
+import { calculateTimePeriod } from '../src/utils';
+
+describe('calculateTimePeriod', () => {
+  // Tuesday, May 26, 2026, 15:30:45 local time
+  const NOW = new Date(2026, 4, 26, 15, 30, 45);
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns now for "now"', () => {
+    const { start, end } = calculateTimePeriod('now', 'now');
+    expect(start.getTime()).toBe(NOW.getTime());
+    expect(end.getTime()).toBe(NOW.getTime());
+  });
+
+  test('defaults `to` to "now"', () => {
+    const { end } = calculateTimePeriod('now-1h');
+    expect(end.getTime()).toBe(NOW.getTime());
+  });
+
+  test('parses a negative offset', () => {
+    const { start } = calculateTimePeriod('now-1h');
+    expect(start).toEqual(new Date(2026, 4, 26, 14, 30, 45));
+  });
+
+  test('parses a positive offset', () => {
+    const { start } = calculateTimePeriod('now+30m');
+    expect(start).toEqual(new Date(2026, 4, 26, 16, 0, 45));
+  });
+
+  test('rounds to start of day', () => {
+    const { start } = calculateTimePeriod('now/d');
+    expect(start).toEqual(new Date(2026, 4, 26, 0, 0, 0));
+  });
+
+  test('offset before rounding gives yesterday midnight', () => {
+    const { start, end } = calculateTimePeriod('now-1d/d', 'now/d');
+    expect(start).toEqual(new Date(2026, 4, 25, 0, 0, 0));
+    expect(end).toEqual(new Date(2026, 4, 26, 0, 0, 0));
+  });
+
+  test('rounding then offset gives today at 07:00', () => {
+    const { start } = calculateTimePeriod('now/d+7h');
+    expect(start).toEqual(new Date(2026, 4, 26, 7, 0, 0));
+  });
+
+  test('offset, rounding, offset gives yesterday at 23:00', () => {
+    const { start } = calculateTimePeriod('now-1d/d+23h');
+    expect(start).toEqual(new Date(2026, 4, 25, 23, 0, 0));
+  });
+
+  test('rounding with negative offset gives yesterday at 23:00', () => {
+    const { start } = calculateTimePeriod('now/d-1h');
+    expect(start).toEqual(new Date(2026, 4, 25, 23, 0, 0));
+  });
+
+  test('quiet hours window: 23:00 yesterday -> 07:00 today', () => {
+    const { start, end } = calculateTimePeriod('now-1d/d+23h', 'now/d+7h');
+    expect(start).toEqual(new Date(2026, 4, 25, 23, 0, 0));
+    expect(end).toEqual(new Date(2026, 4, 26, 7, 0, 0));
+  });
+
+  test.each(['nope', 'now+', 'now-1', 'now1h', 'now/x', 'nowxx', 'now/'])(
+    'throws on invalid input %s',
+    (input) => {
+      expect(() => calculateTimePeriod(input)).toThrow('Invalid time format');
+    },
+  );
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -401,56 +401,69 @@ export function calculateTimePeriod(from: string, to = 'now'): { start: Date; en
   const now = new Date();
 
   function parseTimeString(timeStr: string): Date {
-    if (timeStr === 'now') return now;
-
-    const match = timeStr.match(/^now(-|\+)?(\d+)?([smhdwMy])?(\/(d|w|M|y))?$/);
-    if (!match) throw new Error(`Invalid time format: ${timeStr}`);
-
-    const [, sign, amount, unit, , roundTo] = match;
-    let date = new Date(now);
-
-    if (amount && unit) {
-      const numAmount = parseInt(amount, 10) * (sign === '-' ? -1 : 1);
-      switch (unit) {
-        case 's':
-          date = addSeconds(date, numAmount);
-          break;
-        case 'm':
-          date = addMinutes(date, numAmount);
-          break;
-        case 'h':
-          date = addHours(date, numAmount);
-          break;
-        case 'd':
-          date = addDays(date, numAmount);
-          break;
-        case 'w':
-          date = addWeeks(date, numAmount);
-          break;
-        case 'M':
-          date = addMonths(date, numAmount);
-          break;
-        case 'y':
-          date = addYears(date, numAmount);
-          break;
-      }
+    if (!timeStr.startsWith('now')) {
+      throw new Error(`Invalid time format: ${timeStr}`);
     }
 
-    if (roundTo) {
-      switch (roundTo) {
-        case 'd':
-          date = startOfDay(date);
-          break;
-        case 'w':
-          date = startOfWeek(date);
-          break;
-        case 'M':
-          date = startOfMonth(date);
-          break;
-        case 'y':
-          date = startOfYear(date);
-          break;
+    let date = new Date(now);
+    let rest = timeStr.slice(3);
+
+    // Apply offset (`[+-]N{unit}`) and rounding (`/{unit}`) tokens left-to-right,
+    // so Grafana-style anchors like `now/d+7h` or `now-1d/d+23h` are supported.
+    while (rest.length > 0) {
+      const offsetMatch = rest.match(/^([+-])(\d+)([smhdwMy])/);
+      if (offsetMatch) {
+        const [token, sign, amount, unit] = offsetMatch;
+        const numAmount = parseInt(amount, 10) * (sign === '-' ? -1 : 1);
+        switch (unit) {
+          case 's':
+            date = addSeconds(date, numAmount);
+            break;
+          case 'm':
+            date = addMinutes(date, numAmount);
+            break;
+          case 'h':
+            date = addHours(date, numAmount);
+            break;
+          case 'd':
+            date = addDays(date, numAmount);
+            break;
+          case 'w':
+            date = addWeeks(date, numAmount);
+            break;
+          case 'M':
+            date = addMonths(date, numAmount);
+            break;
+          case 'y':
+            date = addYears(date, numAmount);
+            break;
+        }
+        rest = rest.slice(token.length);
+        continue;
       }
+
+      const roundMatch = rest.match(/^\/([dwMy])/);
+      if (roundMatch) {
+        const [token, roundUnit] = roundMatch;
+        switch (roundUnit) {
+          case 'd':
+            date = startOfDay(date);
+            break;
+          case 'w':
+            date = startOfWeek(date);
+            break;
+          case 'M':
+            date = startOfMonth(date);
+            break;
+          case 'y':
+            date = startOfYear(date);
+            break;
+        }
+        rest = rest.slice(token.length);
+        continue;
+      }
+
+      throw new Error(`Invalid time format: ${timeStr}`);
     }
 
     return date;


### PR DESCRIPTION
Fixes #370.

The `calculateTimePeriod` parser previously rejected Grafana-style anchors with a modifier after a rounding operator (e.g. `now/d+7h`, `now-1d/d+23h`), even though the README claims to follow Grafana's time range format. The parser now applies offset and rounding tokens left-to-right, unblocking windows like "yesterday 23:00 to today 07:00".

## Summary

- Refactored `parseTimeString` in `src/utils.ts` from a single-shot regex into an iterative tokenizer that walks offsets (`[+-]N{unit}`) and roundings (`/{unit}`) left-to-right. No new dependencies.
- Added `__tests__/calculateTimePeriod.test.ts` (none existed) with deterministic time via `jest.setSystemTime`, covering the existing patterns, the new ones (`now/d+7h`, `now-1d/d+23h`, `now/d-1h`), the quiet-hours combo, and invalid-input rejection.
- Documented the new examples and a "Quiet hours (23:00–07:00)" YAML snippet in the Time Period section of the README.

## Examples now supported

| Input            | Meaning                                     |
| ---------------- | ------------------------------------------- |
| `now/d+7h`       | Today at 07:00                              |
| `now-1d/d+23h`   | Yesterday at 23:00                          |
| `now/d-1h`       | Yesterday at 23:00 (equivalent)             |

## Test plan

- [x] `npm run lint` — no new warnings/errors
- [x] `npm test` — 114/114 tests pass across 9 suites, including the new `calculateTimePeriod` suite
- [ ] Manual: configure a card with `time_period_from: "now-1d/d+23h"` and `time_period_to: "now/d+7h"` and confirm the 8-hour window renders correctly
- [ ] Manual: re-test existing patterns (`now-7d`, `now-1d/d` → `now/d`) to confirm no regression